### PR TITLE
Try to fix #4 for cryostream only

### DIFF
--- a/examples/configs/cryo-tcp.yaml
+++ b/examples/configs/cryo-tcp.yaml
@@ -1,15 +1,11 @@
-- tickit.core.components.device_simulation.DeviceSimulation:
-    adapters:
-    - tickit.devices.cryostream.cryostream.CryostreamAdapter: {}
-    device:
-      tickit.devices.cryostream.cryostream.Cryostream: {}
+- tickit.devices.cryostream.Cryostream:
     inputs: {}
     name: cryo
-- tickit.core.components.device_simulation.DeviceSimulation:
-    adapters: []
-    device:
-      tickit.devices.sink.Sink: {}
-    inputs:
-      input: cryo:temperature
-    name: contr_sink
+#- tickit.core.components.device_simulation.DeviceSimulation:
+#    adapters: []
+#    device:
+#      tickit.devices.sink.Sink: {}
+#    inputs:
+#      input: cryo:temperature
+#    name: contr_sink
 

--- a/tickit/adapters/epicsadapter.py
+++ b/tickit/adapters/epicsadapter.py
@@ -8,8 +8,6 @@ from typing import Any, Callable, Dict
 
 from softioc import asyncio_dispatcher, builder, softioc
 
-from tickit.core.adapter import ConfigurableAdapter
-
 
 @dataclass
 class InputRecord:
@@ -27,7 +25,7 @@ class OutputRecord:
     name: str
 
 
-class EpicsAdapter(ConfigurableAdapter):
+class EpicsAdapter:
     """An adapter implementation which acts as an EPICS IOC."""
 
     interrupt_records: Dict[InputRecord, Callable[[], Any]]

--- a/tickit/adapters/servers/tcp.py
+++ b/tickit/adapters/servers/tcp.py
@@ -3,13 +3,12 @@ import logging
 from asyncio.streams import StreamReader, StreamWriter
 from typing import AsyncIterable, Awaitable, Callable, List
 
-from tickit.core.adapter import ConfigurableServer
 from tickit.utils.byte_format import ByteFormat
 
 LOGGER = logging.getLogger(__name__)
 
 
-class TcpServer(ConfigurableServer):
+class TcpServer:
     """A configurable tcp server with delegated message handling for use in adapters."""
 
     def __init__(

--- a/tickit/core/device.py
+++ b/tickit/core/device.py
@@ -1,9 +1,8 @@
 from dataclasses import dataclass
-from typing import Dict, Generic, Hashable, Mapping, Optional, Type, TypeVar
+from typing import Generic, Hashable, Mapping, Optional, TypeVar
 
 from tickit.core.typedefs import SimTime
 from tickit.utils.compat.typing_compat import Protocol, runtime_checkable
-from tickit.utils.configuration.configurable import configurable, configurable_base
 
 #: A bound typevar for mappings of device inputs
 InMap = TypeVar("InMap", bound=Mapping[str, Hashable])
@@ -42,43 +41,3 @@ class Device(Protocol):
             inputs: A mapping of device inputs and their values.
         """
         pass
-
-
-@configurable_base
-@dataclass
-class DeviceConfig:
-    """A data container for device configuration.
-
-    A data container for device configuration which acts as a named union of subclasses
-    to facilitate automatic deserialization.
-    """
-
-    @staticmethod
-    def configures() -> Type[Device]:
-        """A static method which returns the Device class configured by this config.
-
-        Returns:
-            Type[Device]: The Device class configured by this config.
-        """
-        raise NotImplementedError
-
-    @property
-    def kwargs(self) -> Dict[str, object]:
-        """A property which returns the key word arguments of the configured device.
-
-        Returns:
-            Dict[str, object]: The key word argument of the configured Device.
-        """
-        raise NotImplementedError
-
-
-class ConfigurableDevice:
-    """A mixin used to create a device with a configuration data container."""
-
-    def __init_subclass__(cls) -> None:
-        """A subclass init method which makes the subclass configurable.
-
-        A subclass init method which makes the subclass configurable with a
-        DeviceConfig template.
-        """
-        cls = configurable(DeviceConfig)(cls)

--- a/tickit/devices/cryostream/__init__.py
+++ b/tickit/devices/cryostream/__init__.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from typing import Type
+
+from tickit.core.components.component import BaseComponent, ComponentConfig
+from tickit.core.components.device_simulation import DeviceSimulation
+from tickit.core.state_interfaces.state_interface import StateConsumer, StateProducer
+
+from .cryostream import CryostreamAdapter, CryostreamDevice
+
+
+@dataclass
+class Cryostream(ComponentConfig):
+    host: str = "localhost"
+    port: int = 25565
+
+    def __call__(
+        self, state_consumer: Type[StateConsumer], state_producer: Type[StateProducer]
+    ) -> BaseComponent:
+        device = CryostreamDevice()
+        return DeviceSimulation(
+            name=self.name,
+            state_consumer=state_consumer,
+            state_producer=state_producer,
+            adapters=[CryostreamAdapter(host=self.host, port=self.port)],
+            device=device,
+        )

--- a/tickit/utils/configuration/configurable.py
+++ b/tickit/utils/configuration/configurable.py
@@ -1,22 +1,14 @@
-from dataclasses import is_dataclass, make_dataclass
-from inspect import Parameter, signature
-from typing import Any, Callable, Dict, Iterator, Sequence, Set, Type, TypeVar
+from typing import Any, Dict, Iterator, TypeVar
 
-from apischema import deserializer, serializer
-from apischema.conversions.conversions import Conversion
+from apischema import deserializer
+from apischema.conversions import Conversion
 from apischema.tagged_unions import Tagged, TaggedUnion, get_tagged
-
-from tickit.utils.compat.typing_compat import Protocol, runtime_checkable
 
 # Implementation adapted from apischema example: Class as tagged union of its subclasses
 # see: https://wyfo.github.io/apischema/examples/subclass_tagged_union/
 
-#: A function or method
-Func = TypeVar("Func", bound=Callable)
 #: A class
 Cls = TypeVar("Cls", bound=type)
-#: A configurable type
-T = TypeVar("T", covariant=True)
 
 
 def rec_subclasses(cls: type) -> Iterator[type]:
@@ -33,19 +25,7 @@ def rec_subclasses(cls: type) -> Iterator[type]:
         yield from rec_subclasses(sub_cls)
 
 
-def configurable_alias(sub: Type) -> str:
-    """Gets the alias of a configurable sub-class.
-
-    Args:
-        sub (Type): The sub-class to be aliased.
-
-    Returns:
-        str: The alias assigned to the sub-class.
-    """
-    return sub.configures().__module__ + "." + sub.configures().__name__
-
-
-def configurable_base(cls: Cls) -> Cls:
+def as_tagged_union(cls: Cls) -> Cls:
     """A decorator to make a config base class which can deserialize aliased sub-classes.
 
     A decorator which makes a config class the root of a tagged union of sub-classes
@@ -60,41 +40,13 @@ def configurable_base(cls: Cls) -> Cls:
     Returns:
         Cls: The modified config base class.
     """
-
-    def serialization() -> Conversion:
-        """Create an apischema Conversion with a converter for recursive sub-classes.
-
-        Returns:
-            Conversion: An apischema Conversion with a converter for recursive
-                sub-classes.
-        """
-        serialization_union = type(
-            cls.__name__,
-            (TaggedUnion,),
-            {
-                "__annotations__": {
-                    configurable_alias(sub): Tagged[sub]  # type: ignore
-                    for sub in rec_subclasses(cls)
-                }
-            },
-        )
-        return Conversion(
-            lambda obj: serialization_union(**{configurable_alias(obj.__class__): obj}),
-            source=cls,
-            target=serialization_union,
-            inherited=False,
-        )
-
+    # This will only be used if we want to generate a json schema (which we will)
     def deserialization() -> Conversion:
-        """Create an apischema Conversion which gets a sub-class by tag.
-
-        Returns:
-            Conversion: An apischema Conversion which gets a sub-class by tag.
-        """
         annotations: Dict[str, Any] = {}
         deserialization_namespace: Dict[str, Any] = {"__annotations__": annotations}
         for sub in rec_subclasses(cls):
-            annotations[configurable_alias(sub)] = Tagged[sub]  # type: ignore
+            fullname = sub.__module__ + "." + sub.__name__
+            annotations[fullname] = Tagged[sub]  # type: ignore
         deserialization_union = type(
             cls.__name__,
             (TaggedUnion,),
@@ -105,98 +57,4 @@ def configurable_base(cls: Cls) -> Cls:
         )
 
     deserializer(lazy=deserialization, target=cls)
-    serializer(lazy=serialization, source=cls)
     return cls
-
-
-@runtime_checkable
-class Config(Protocol[T]):
-    """An interface for types which implement configurations."""
-
-    @staticmethod
-    def configures() -> Type[T]:
-        """A static method which returns the class configured by this config.
-
-        Returns:
-            Type[T]: The class configured by this config.
-        """
-        pass
-
-    @property
-    def kwargs(self) -> Dict[str, object]:
-        """A property which returns the key word arguments of the configured class.
-
-        Returns:
-            Dict[str, object]: The key word argument of the configured class.
-        """
-        pass
-
-
-def configurable(template: Type, ignore: Sequence[str] = []) -> Callable[[Type], Type]:
-    """A decorator to add a config data container sub-class to a class.
-
-    A decorator to make a class configurable by adding a config data container
-    sub-class which is typically registered against a configurable base class allowing
-    for serialization & deserialization by union tagging.
-
-    Args:
-        template (Type): A template dataclass from which fields are borrwoed
-        ignore (Sequence[str]): Fields which should not be serialized / deserialized.
-            Defaults to [].
-
-    Returns:
-        Callable[[Type], Type]: A decorator which adds the config data container.
-    """
-    assert is_dataclass(template)
-
-    def add_config(cls: Type) -> Type:
-        """A decorator to add a config data container sub-class to a class.
-
-        Args:
-            cls (Type): The class to which the config data container should be added.
-
-        Returns:
-            Type: The modified class.
-        """
-
-        def configures() -> Type:
-            return cls
-
-        def kwargs(self) -> Dict[str, object]:
-            remove: Set[str] = (
-                set(template.__annotations__)
-                if hasattr(template, "__annotations__")
-                else set()
-            )
-            return {k: self.__dict__[k] for k in set(self.__dict__) - remove}
-
-        signature_items = set(
-            (name, param)
-            for typ in (template, cls)
-            for name, param in signature(typ).parameters.items()
-            if name not in ignore
-        )
-
-        config_data_class: Type = make_dataclass(
-            f"{cls.__name__}Config",
-            sorted(
-                (
-                    (name, param.annotation)
-                    if param.default is Parameter.empty
-                    else (name, param.annotation, param.default)
-                    for name, param in signature_items
-                ),
-                key=len,
-            ),
-            bases=(template,),
-            namespace={
-                "configures": staticmethod(configures),
-                "kwargs": property(kwargs),
-                "__doc__": cls.__init__.__doc__,
-            },
-        )
-
-        setattr(cls, config_data_class.__qualname__, config_data_class)
-        return cls
-
-    return add_config


### PR DESCRIPTION
The YAML looks cleaner now, but there's some ugliness:

- `DeviceSimulation` sets `Adapter.device` and `Adapter.raise_interrupt`, mypy complains about the latter
- `Component` vs `BaseComponent`, mypy doesn't like returning a `DeviceSimulation` when the call signature says it wants a `Component`
- I find myself wanting to write `class TCPServer(Server)`. Should `Server`, `Adapter`, `Component` be abstract base classes instead of protocols?
- Does the contents of `configurable.py` belong in `component.py`?

I expect there will be more issues as I convert the rest, but I wanted to PR early...