### PR TITLE
Fix typing compat

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,8 @@ Changed:
   - User may now reference the :code:`ComponentConfig`, which encapsulate a device and adapters
   - Device & Adapter config classes are no longer autmatically generated, configuration should be performed via the :code:`ComponentConfig`
 
+- Made :code:`Device` a typed :code:`Generic` of :code:`InMap` and :code:`OutMap`
+
 Deprecated:
 
 Removed:
@@ -37,6 +39,7 @@ Fixed:
 
 - Cryostream flow rate threshold (from 900K > 90K)
 - Added dependency on Click to :code:`setup.cfg`
+- Added missing :code:`__init__.py` to :code:`tickit.utils.compat`
 
 Security:
 

--- a/tickit/core/device.py
+++ b/tickit/core/device.py
@@ -24,7 +24,7 @@ class DeviceUpdate(Generic[OutMap]):
 
 
 @as_tagged_union
-class Device:
+class Device(Generic[InMap, OutMap]):
     """An interface for types which implement simulated devices."""
 
     def update(self, time: SimTime, inputs: InMap) -> DeviceUpdate[OutMap]:


### PR DESCRIPTION
Fixes #5 by:
- Adding `__init__,py` to `tickit.utils.compat` to enable mypy to access `tickit.utils.typing_compat`
- Making `Device` a typed `Generic` of `InMap` and `OutMap`