### PR TITLE
Create simple box device for memory input/output

### DIFF
--- a/src/tickit/devices/iobox.py
+++ b/src/tickit/devices/iobox.py
@@ -17,7 +17,7 @@ class IoBoxDevice(Device, Generic[A, V]):
     """A simple device which can take and store key-value pairs.
 
     Adapter should write values to the device via device.write(addr, value)
-    or device[addr] = value. The writes will be pending until the adapter
+    or device[addr] = value. The writes will be pending until the scheduler
     interrupts the device. For example:
 
     ```python

--- a/src/tickit/devices/iobox.py
+++ b/src/tickit/devices/iobox.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, Generic, List, Tuple, TypeVar
+from typing import Dict, Generic, List, Tuple, TypeVar
 
 from tickit.core.components.component import Component, ComponentConfig
 from tickit.core.components.device_simulation import DeviceSimulation
@@ -45,7 +45,7 @@ class IoBoxDevice(Device, Generic[A, V]):
     _memory: Dict[A, V]
     _change_buffer: List[Tuple[A, V]]
 
-    def __init__(self) -> None:
+    def __init__(self) -> None:  # noqa: D107
         self._memory = {}
         self._change_buffer = []
 

--- a/tests/devices/test_iobox.py
+++ b/tests/devices/test_iobox.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+import pytest
+
+from tickit.core.typedefs import SimTime
+from tickit.devices.iobox import IoBoxDevice
+
+
+@pytest.fixture
+def box() -> IoBoxDevice[int, Any]:
+    return IoBoxDevice()
+
+
+def test_raises_error_if_no_values(box: IoBoxDevice[int, Any]) -> None:
+    with pytest.raises(KeyError):
+        box.read(4)
+
+
+def test_writes_pending_until_update(box: IoBoxDevice[int, Any]):
+    box.write(4, "foo")
+    box.update(SimTime(0), {})
+    assert "foo" == box.read(4)
+    box.write(4, "bar")
+    assert "foo" == box.read(4)
+    box.update(SimTime(0), {})
+    assert "bar" == box.read(4)

--- a/tests/devices/test_iobox.py
+++ b/tests/devices/test_iobox.py
@@ -16,7 +16,7 @@ def test_raises_error_if_no_values(box: IoBoxDevice[int, Any]) -> None:
         box.read(4)
 
 
-def test_writes_pending_until_update(box: IoBoxDevice[int, Any]):
+def test_writes_pending_until_update(box: IoBoxDevice[int, Any]) -> None:
     box.write(4, "foo")
     box.update(SimTime(0), {})
     assert "foo" == box.read(4)
@@ -24,3 +24,27 @@ def test_writes_pending_until_update(box: IoBoxDevice[int, Any]):
     assert "foo" == box.read(4)
     box.update(SimTime(0), {})
     assert "bar" == box.read(4)
+
+
+def test_outputs_change(box: IoBoxDevice[int, Any]) -> None:
+    box.write(4, "foo")
+    update = box.update(SimTime(0), {})
+    assert update.outputs["updates"] == [(4, "foo")]
+
+
+def test_outputs_only_last_changes(box: IoBoxDevice[int, Any]) -> None:
+    box.write(4, "foo")
+    box.update(SimTime(0), {})
+    box.write(3, "bar")
+    update = box.update(SimTime(0), {})
+    assert update.outputs["updates"] == [(3, "bar")]
+
+
+def test_writes_input(box: IoBoxDevice[int, Any]) -> None:
+    box.update(SimTime(0), {"updates": [(4, "foo")]})
+    assert box.read(4) == "foo"
+
+
+def test_propagates_input(box: IoBoxDevice[int, Any]) -> None:
+    update = box.update(SimTime(0), {"updates": [(4, "foo")]})
+    assert update.outputs["updates"] == [(4, "foo")]


### PR DESCRIPTION
This PR just illustrates an idea that came up in discussion with @abbiemery, not necessarily to be merged. 

The envisioned use of this class is where you wish to simulate a network interface but the internal hardware logic is either not needed or very simple. A custom adapter can be made for the network interface and can simply read and write to an IoBox. I wondered if a lot of people would write devices like this and if it would make sense for tickit to provide a simple helper device.

Any thoughts welcome.