### PR TITLE
Add DecodingInterpreter and EncodingInterpreter

### DIFF
--- a/tests/adapters/interpreters/wrappers/test_recoding_interpreter.py
+++ b/tests/adapters/interpreters/wrappers/test_recoding_interpreter.py
@@ -1,0 +1,57 @@
+import pytest
+from mock import ANY, AsyncMock
+
+from tickit.adapters.interpreters.wrappers import (
+    DecodingInterpreter,
+    EncodingInterpreter,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("message, encoding", [("hello", "utf-8"), ("test", "utf-32")])
+async def test_decoding_interpreter_decodes_bytes_correctly(message, encoding):
+    mock_interpreter = AsyncMock()
+    decoding_interpreter = DecodingInterpreter(mock_interpreter, encoding=encoding)
+    await decoding_interpreter.handle(AsyncMock(), message.encode(encoding))
+    mock_interpreter.handle.assert_called_once_with(ANY, message)
+
+
+@pytest.mark.asyncio
+async def test_decoding_interpreter_handles_strings_correctly():
+    mock_interpreter = AsyncMock()
+    decoding_interpreter = DecodingInterpreter(mock_interpreter)
+    await decoding_interpreter.handle(AsyncMock(), "test")
+    mock_interpreter.handle.assert_called_once_with(ANY, "test")
+
+
+@pytest.mark.asyncio
+async def test_decoding_interpreter_default_encoding():
+    mock_interpreter = AsyncMock()
+    decoding_interpreter = DecodingInterpreter(mock_interpreter)
+    await decoding_interpreter.handle(AsyncMock(), "test".encode("utf-8"))
+    mock_interpreter.handle.assert_called_once_with(ANY, "test")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("message, encoding", [("hello", "utf-8"), ("test", "utf-32")])
+async def test_encoding_interpreter_encodes_strings_correctly(message, encoding):
+    mock_interpreter = AsyncMock()
+    encoding_interpreter = EncodingInterpreter(mock_interpreter, encoding=encoding)
+    await encoding_interpreter.handle(AsyncMock(), message)
+    mock_interpreter.handle.assert_called_once_with(ANY, message.encode(encoding))
+
+
+@pytest.mark.asyncio
+async def test_encoding_interpreter_handles_bytes_corrrectly():
+    mock_interpreter = AsyncMock()
+    encoding_interpreter = EncodingInterpreter(mock_interpreter)
+    await encoding_interpreter.handle(AsyncMock(), b"test")
+    mock_interpreter.handle.assert_called_once_with(ANY, b"test")
+
+
+@pytest.mark.asyncio
+async def test_encoding_interpreter_default_encoding():
+    mock_interpreter = AsyncMock()
+    encoding_interpreter = EncodingInterpreter(mock_interpreter)
+    await encoding_interpreter.handle(AsyncMock(), "test")
+    mock_interpreter.handle.assert_called_once_with(ANY, "test".encode("utf-8"))

--- a/tickit/adapters/interpreters/wrappers/__init__.py
+++ b/tickit/adapters/interpreters/wrappers/__init__.py
@@ -1,5 +1,9 @@
 from tickit.adapters.interpreters.wrappers.beheading_interpreter import (
     BeheadingInterpreter,
 )
+from tickit.adapters.interpreters.wrappers.recoding_interpreter import (
+    DecodingInterpreter,
+    EncodingInterpreter,
+)
 
-__all__ = ["BeheadingInterpreter"]
+__all__ = ["BeheadingInterpreter", "DecodingInterpreter", "EncodingInterpreter"]

--- a/tickit/adapters/interpreters/wrappers/recoding_interpreter.py
+++ b/tickit/adapters/interpreters/wrappers/recoding_interpreter.py
@@ -1,0 +1,85 @@
+from typing import AnyStr, AsyncIterable, Tuple, cast
+
+from tickit.core.adapter import Adapter, Interpreter
+
+
+class DecodingInterpreter(Interpreter[AnyStr]):
+    """A wrapper for an interpreter that decodes messages.
+
+    An interpreter wrapper class that recieves messages, decodes them, and then passes
+    them on to the wrapped interpreter to handle.
+    """
+
+    def __init__(
+        self, interpreter: Interpreter[AnyStr], encoding: str = "utf-8"
+    ) -> None:
+        """A wrapper for an interpreter that decodes messages.
+
+        Args:
+            interpreter (Interpreter): The interpreter decoded messages are passed to.
+            encoding (str): The encoding with which to decode the incoming message.
+        """
+        self.interpreter: Interpreter[AnyStr] = interpreter
+        self.encoding = encoding
+        super().__init__()
+
+    async def handle(
+        self, adapter: Adapter, message: AnyStr
+    ) -> Tuple[AsyncIterable[AnyStr], bool]:
+        """Decodes a message and passes it on to be handled by the wrapped interpreter.
+
+        Args:
+            adapter (Adapter): The adapter in which the function should be executed.
+            message: (AnyStr): The message to be handled.
+
+        Returns:
+            Tuple[AsyncIterable[Union[str, bytes]], bool]:
+                A tuple of the asynchronous iterable of replies and a flag indicating
+                whether an interrupt should be raised by the adapter.
+        """
+        if type(message) == bytes:
+            decoded_message = cast(bytes, message).decode(encoding=self.encoding)
+        else:
+            decoded_message = cast(str, message)
+        return await self.interpreter.handle(adapter, cast(AnyStr, decoded_message))
+
+
+class EncodingInterpreter(Interpreter[AnyStr]):
+    """A wrapper for an interpreter that encodes messages.
+
+    An interpreter wrapper class that recieves messages, encodes them, and then passes
+    them on to the wrapped interpreter to handle.
+    """
+
+    def __init__(
+        self, interpreter: Interpreter[AnyStr], encoding: str = "utf-8"
+    ) -> None:
+        """A wrapper for an interpreter that encodes messages.
+
+        Args:
+            interpreter (Interpreter): The interpreter encoded messages are passed to.
+            encoding (str): The encoding with which to encode the incoming message.
+        """
+        self.interpreter: Interpreter[AnyStr] = interpreter
+        self.encoding = encoding
+        super().__init__()
+
+    async def handle(
+        self, adapter: Adapter, message: AnyStr
+    ) -> Tuple[AsyncIterable[AnyStr], bool]:
+        """Encodes a message and passes it on to be handled by the wrapped interpreter.
+
+        Args:
+            adapter (Adapter): The adapter in which the function should be executed.
+            message: (AnyStr): The message to be handled.
+
+        Returns:
+            Tuple[AsyncIterable[Union[str, bytes]], bool]:
+                A tuple of the asynchronous iterable of replies and a flag indicating
+                whether an interrupt should be raised by the adapter.
+        """
+        if type(message) == str:
+            encoded_message = cast(str, message).encode(encoding=self.encoding)
+        else:
+            encoded_message = cast(bytes, message)
+        return await self.interpreter.handle(adapter, cast(AnyStr, encoded_message))


### PR DESCRIPTION
Adds interpreter wrappers that decode/encode messages before passing them on to the wrapped interpreter. This should facilitate the removal of encoding/decoding logic from within `RegexCommand`.