### PR TITLE
93 change regex command

### DIFF
--- a/tests/adapters/interpreters/command/test_command_interpreter.py
+++ b/tests/adapters/interpreters/command/test_command_interpreter.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Callable, Optional, Sequence
+from typing import Callable, Optional, Sequence, Tuple
 
 import pytest
 from mock import AsyncMock, MagicMock, patch
@@ -11,6 +11,8 @@ from tickit.core.adapter import Adapter
 _GET_TYPE_HINTS = (
     "tickit.adapters.interpreters.command.command_interpreter.get_type_hints"
 )
+
+MOCK_PARSE_RETURN = (("arg1", "arg2"), 1, 2, 2)
 
 
 @pytest.fixture
@@ -28,9 +30,9 @@ def TestCommand():
             setattr(func, "__command__", self)
             return func
 
-        def parse(self, data: bytes) -> Optional[Sequence[str]]:
+        def parse(self, data: bytes) -> Optional[Tuple[Sequence[str], int, int, int]]:
             if data == self.command:
-                return ("arg1", "arg2")
+                return MOCK_PARSE_RETURN
             else:
                 return None
 
@@ -51,7 +53,7 @@ async def test_command_interpreter_handle_calls_func_with_args(
             __command__=MagicMock(
                 Command,
                 interrupt=False,
-                parse=MagicMock(return_value=("arg1", "arg2")),
+                parse=MagicMock(return_value=MOCK_PARSE_RETURN),
             ),
         ),
     )
@@ -74,7 +76,7 @@ async def test_command_interpreter_handle_returns_iterable_reply(
             __command__=MagicMock(
                 Command,
                 interrupt=False,
-                parse=MagicMock(return_value=("arg1", "arg2")),
+                parse=MagicMock(return_value=MOCK_PARSE_RETURN),
             ),
             return_value=reply,
         ),
@@ -97,7 +99,7 @@ async def test_command_interpreter_handle_wraps_non_iterable_reply(
             __command__=MagicMock(
                 Command,
                 interrupt=False,
-                parse=MagicMock(return_value=("arg1", "arg2")),
+                parse=MagicMock(return_value=MOCK_PARSE_RETURN),
             ),
             return_value=reply,
         ),
@@ -125,7 +127,7 @@ async def test_command_interpreter_handle_returns_interupt(
             __command__=MagicMock(
                 Command,
                 interrupt=interrupt,
-                parse=MagicMock(return_value=("arg1", "arg2")),
+                parse=MagicMock(return_value=MOCK_PARSE_RETURN),
             ),
             return_value="DummyReply",
         ),
@@ -174,3 +176,48 @@ async def test_command_interpreter_handle_returns_message_for_no_commands(
         .__aiter__()
         .__anext__()
     )
+
+
+@patch(
+    _GET_TYPE_HINTS,
+    lambda _: {"arg1": str, "arg2": str},
+)
+@pytest.mark.asyncio
+@pytest.mark.parametrize("match_end, expected_num_awaits", [(2, 0), (3, 1)])
+async def test_command_interpreter_matches_commands_against_full_message(
+    command_interpreter: CommandInterpreter, match_end: int, expected_num_awaits: int
+):
+    test_adapter = MagicMock(
+        Adapter,
+        test_method=AsyncMock(
+            __command__=MagicMock(
+                Command,
+                interrupt=False,
+                parse=MagicMock(return_value=(("arg1", "arg2"), 1, match_end, 3)),
+            ),
+        ),
+    )
+    await command_interpreter.handle(test_adapter, b"\x01")
+    assert test_adapter.test_method.await_count == expected_num_awaits
+
+
+@patch(
+    _GET_TYPE_HINTS,
+    lambda _: {"arg1": int, "arg2": float},
+)
+@pytest.mark.asyncio
+async def test_command_interpreter_converts_args_to_types_correctly(
+    command_interpreter: CommandInterpreter,
+):
+    test_adapter = MagicMock(
+        Adapter,
+        test_method=AsyncMock(
+            __command__=MagicMock(
+                Command,
+                interrupt=False,
+                parse=MagicMock(return_value=(("1", "1.0"), 1, 3, 3)),
+            ),
+        ),
+    )
+    await command_interpreter.handle(test_adapter, b"\x01")
+    assert test_adapter.test_method.awaited_with([int(1), float(1.0)])

--- a/tests/adapters/interpreters/command/test_regex_command.py
+++ b/tests/adapters/interpreters/command/test_regex_command.py
@@ -50,4 +50,74 @@ def test_regex_command_parse_unmatched_returns_none(
 def test_regex_command_parse_match_returns_args(
     regex_command: RegexCommand, message: bytes, expected: Tuple[object]
 ):
-    assert expected == regex_command.parse(message)
+    result = regex_command.parse(message)
+    assert result is not None
+    args, _, _, _ = result
+    assert expected == args
+
+
+@pytest.mark.parametrize(
+    ["regex", "interrupt", "format", "message", "expected"],
+    [
+        (r"(Test)Message", False, None, r"TestMessage", ("Test",)),
+        (b"\\x01(.)", False, None, b"\x01\x02", (b"\x02",)),
+    ],
+)
+def test_regex_command_parse_can_take_anystr(
+    regex_command: RegexCommand, message: AnyStr, expected
+):
+    result = regex_command.parse(message)
+    assert result is not None
+    args, _, _, _ = result
+    assert expected == args
+
+
+@pytest.mark.parametrize(
+    ["regex", "interrupt", "format", "message", "expected_end_of_match"],
+    [
+        (r"Test", False, None, r"TestMessage", 4),
+        (r"Test", False, "utf-32", "TestMessage".encode("utf-32"), 20),
+    ],
+)
+def test_parse_gives_right_end(
+    regex_command: RegexCommand, message: AnyStr, expected_end_of_match
+):
+    result = regex_command.parse(message)
+    assert result is not None
+    _, _, end, _ = result
+    assert end == expected_end_of_match
+
+
+@pytest.mark.parametrize(
+    ["regex", "interrupt", "format", "message", "expected_end_of_match"],
+    [
+        (r"Test", False, None, r"\nTest\r\n", 6),
+        (r"Test", False, "utf-8", b"\nTest\r\n", 4),
+    ],
+)
+def test_parse_strips_correctly_when_formatting(
+    regex_command: RegexCommand, message: AnyStr, expected_end_of_match
+):
+    result = regex_command.parse(message)
+    assert result is not None
+    _, _, end, _ = result
+    assert end == expected_end_of_match
+
+
+@pytest.mark.parametrize(
+    ["regex", "interrupt", "format", "message", "full_match_expected"],
+    [
+        (r"Test", False, None, r"\nTest\r\n", False),
+        (r"Test", False, "utf-8", b"\nTest\r\n", True),
+        (rb"Test", False, "utf-8", b"\nTest\r\n", False),
+        (rb"Test", False, None, b"\nTest\r\n", False),
+    ],
+)
+def test_parse_gives_correct_whole_matches(
+    regex_command: RegexCommand, message: AnyStr, full_match_expected
+):
+    result = regex_command.parse(message)
+    assert result is not None
+    _, _, end, message_length = result
+    full_match = end == message_length
+    assert full_match == full_match_expected

--- a/tests/adapters/interpreters/wrappers/test_joining_interpreter.py
+++ b/tests/adapters/interpreters/wrappers/test_joining_interpreter.py
@@ -1,0 +1,17 @@
+import pytest
+from mock import AsyncMock
+
+from tickit.adapters.interpreters.wrappers import JoiningInterpreter
+
+
+@pytest.mark.asyncio
+async def test_joining_interpreterconcatenates_as_expected():
+    async def multi_resp(msgs):
+        for msg in msgs:
+            yield msg
+
+    mock_interpreter = AsyncMock()
+    mock_interpreter.handle.return_value = multi_resp(["one", "two", "three"]), True
+    joining_interpreter = JoiningInterpreter(mock_interpreter, response_delimiter="-")
+    result, _ = await joining_interpreter.handle(AsyncMock(), "test")
+    assert [msg async for msg in result] == ["one-two-three"]

--- a/tickit/adapters/interpreters/command/regex_command.py
+++ b/tickit/adapters/interpreters/command/regex_command.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass
-from typing import AnyStr, Callable, Generic, Optional, Sequence
+from typing import AnyStr, Callable, Generic, Optional, Sequence, Tuple, cast
 
 
 @dataclass(frozen=True)
@@ -36,24 +36,78 @@ class RegexCommand(Generic[AnyStr]):
         setattr(func, "__command__", self)
         return func
 
-    def parse(self, data: bytes) -> Optional[Sequence[AnyStr]]:
+    # def parse(self, data: AnyStr) -> Optional[Sequence[AnyStr]]:
+    #     """Performs message decoding and regex matching to match and extract args.
+
+    #     A method which performs message decoding accoridng to the command formatting
+    #     string, checks for a full regular expression match and returns a sequence of
+    #     function arguments if a match is found, otherwise the method returns None.
+
+    #     Args:
+    #         data (bytes): The message data to be parsed.
+
+    #     Returns:
+    #         Optional[Sequence[AnyStr]]:
+    #             If a full match is found a sequence of function arguments is returned,
+    #             otherwise the method returns None.
+    #     """
+    #     if isinstance(data, bytes):
+    #         message = cast(bytes, data)
+    #         message_formatted = (
+    #             message.decode(self.format, "ignore").strip() if self.format else data
+    #         )
+    #     else:
+    #         message_formatted = data
+    #     if isinstance(message_formatted, type(self.regex)):
+    #         match = re.fullmatch(self.regex, message_formatted)
+    #         if match:
+    #             return match.groups()
+    #     return None
+
+    def parse(self, data: AnyStr) -> Optional[Tuple[Sequence[AnyStr], int, int, int]]:
         """Performs message decoding and regex matching to match and extract arguments.
 
         A method which performs message decoding accoridng to the command formatting
-        string, checks for a full regular expression match and returns a sequence of
-        function arguments if a match is found, otherwise the method returns None.
+        string, checks for a regular expression match using re.search. If a match is
+        found, it returns a sequence of function arguments together with some integers
+        giving information about the match, otherwise the method returns None.
 
         Args:
             data (bytes): The message data to be parsed.
 
         Returns:
-            Optional[Sequence[AnyStr]]:
-                If a full match is found a sequence of function arguments is returned,
-                otherwise the method returns None.
+            Optional[Tuple[Sequence[AnyStr], int, int, int]]:
+                If a match is found a sequence of function arguments is returned,
+                together with three integers corresponding to the start and end indices
+                of the match with respect to the (foramtted) data as well as the length
+                of the (formatted) data; otherwise the method returns None.
         """
-        message = data.decode(self.format, "ignore").strip() if self.format else data
-        if isinstance(message, type(self.regex)):
-            match = re.fullmatch(self.regex, message)
-            if match:
-                return match.groups()
+        to_format = (
+            self.format and isinstance(data, bytes) and isinstance(self.regex, str)
+        )
+        if to_format:  # isinstance(data, bytes) and isinstance(self.regex, str):
+            # We only want to format if matching a string pattern against bytes data.
+            # Formatting consists of encoding the pattern and stripping the data of
+            # ascii whitespace.
+            regex_formatted = cast(str, self.regex).encode(
+                cast(str, self.format), "ignore"
+            )
+            regex_formatted = regex_formatted
+            message = data.strip()
+        else:
+            regex_formatted = cast(bytes, self.regex)
+            message = data
+        if isinstance(message, type(regex_formatted)):
+            match = re.search(regex_formatted, message)
+            if match is None:
+                return None
+            match_groups = match.groups()
+            match_start = match.start()
+            match_end = match.end()
+            formatted_message_length = len(message)
+            if to_format:
+                match_groups = tuple(
+                    (group.decode(cast(str, self.format)) for group in match_groups)
+                )
+            return match_groups, match_start, match_end, formatted_message_length
         return None

--- a/tickit/adapters/interpreters/command/regex_command.py
+++ b/tickit/adapters/interpreters/command/regex_command.py
@@ -36,34 +36,6 @@ class RegexCommand(Generic[AnyStr]):
         setattr(func, "__command__", self)
         return func
 
-    # def parse(self, data: AnyStr) -> Optional[Sequence[AnyStr]]:
-    #     """Performs message decoding and regex matching to match and extract args.
-
-    #     A method which performs message decoding accoridng to the command formatting
-    #     string, checks for a full regular expression match and returns a sequence of
-    #     function arguments if a match is found, otherwise the method returns None.
-
-    #     Args:
-    #         data (bytes): The message data to be parsed.
-
-    #     Returns:
-    #         Optional[Sequence[AnyStr]]:
-    #             If a full match is found a sequence of function arguments is returned,
-    #             otherwise the method returns None.
-    #     """
-    #     if isinstance(data, bytes):
-    #         message = cast(bytes, data)
-    #         message_formatted = (
-    #             message.decode(self.format, "ignore").strip() if self.format else data
-    #         )
-    #     else:
-    #         message_formatted = data
-    #     if isinstance(message_formatted, type(self.regex)):
-    #         match = re.fullmatch(self.regex, message_formatted)
-    #         if match:
-    #             return match.groups()
-    #     return None
-
     def parse(self, data: AnyStr) -> Optional[Tuple[Sequence[AnyStr], int, int, int]]:
         """Performs message decoding and regex matching to match and extract arguments.
 

--- a/tickit/adapters/interpreters/utils.py
+++ b/tickit/adapters/interpreters/utils.py
@@ -1,0 +1,13 @@
+from typing import AnyStr, AsyncIterable
+
+
+async def wrap_as_async_iterable(message: AnyStr) -> AsyncIterable[AnyStr]:
+    """Wraps a message in an asynchronous iterable.
+
+    Args:
+        message (AnyStr): A singular message.
+
+    Returns:
+        AsyncIterable[AnyStr]: An asynchronous iterable containing the message.
+    """
+    yield message

--- a/tickit/adapters/interpreters/wrappers/__init__.py
+++ b/tickit/adapters/interpreters/wrappers/__init__.py
@@ -1,5 +1,6 @@
 from tickit.adapters.interpreters.wrappers.beheading_interpreter import (
     BeheadingInterpreter,
 )
+from tickit.adapters.interpreters.wrappers.joining_interpreter import JoiningInterpreter
 
-__all__ = ["BeheadingInterpreter"]
+__all__ = ["BeheadingInterpreter", "JoiningInterpreter"]

--- a/tickit/adapters/interpreters/wrappers/joining_interpreter.py
+++ b/tickit/adapters/interpreters/wrappers/joining_interpreter.py
@@ -1,0 +1,75 @@
+from typing import AnyStr, AsyncIterable, Tuple
+
+from tickit.adapters.interpreters.utils import wrap_as_async_iterable
+from tickit.core.adapter import Adapter, Interpreter
+
+
+class JoiningInterpreter(Interpreter[AnyStr]):
+    """A wrapper for an interpreter that combines responses.
+
+    An interpreter wrapper class that takes the wrapped interpreter's response(s) to a
+    message and combines them into a single response.
+    """
+
+    def __init__(
+        self,
+        interpreter: Interpreter[AnyStr],
+        response_delimiter: AnyStr,
+    ) -> None:
+        """A decorator for an interpreter that combines multiple responses into one.
+
+        Args:
+            interpreter (Interpreter): The interpreter responding to a message.
+            response_delimiter (AnyStr): The delimiter separating the responses to the
+                individual responses when they are combined into a single response
+                message.
+
+        """
+        super().__init__()
+        self.interpreter: Interpreter[AnyStr] = interpreter
+        self.response_delimiter: AnyStr = response_delimiter
+
+    async def _combine_responses(
+        self, responses: AsyncIterable[AnyStr]
+    ) -> AsyncIterable[AnyStr]:
+        """Combines results from handling multiple messages.
+
+        Takes the responses from when the wrapped interpreter handles multiple messages
+        and returns an appropriate composite repsonse and interrrupt. The composite
+        response is the concatentation of each of the individual responses, the
+        composite interrupt is a logical inclusive 'or' of all of the individual
+        responses.
+
+        Args:
+            responses (AsyncIterable[AnyStr]): an async iterable of reply messages from
+                the wrapped class' handle() method.
+
+        Returns:
+            AsyncIterable[AnyStr]:
+                An asynchronous iterable containing a single reply message.
+        """
+        response_list = [response async for response in responses]
+        response = self.response_delimiter.join(response_list)
+        resp = wrap_as_async_iterable(response)
+        return resp
+
+    async def handle(
+        self, adapter: Adapter, message: AnyStr
+    ) -> Tuple[AsyncIterable[AnyStr], bool]:
+        """Merges the responses from an interpreter into a single message.
+
+        Individual responses to the message are combined into a single response and
+            returned.
+
+        Args:
+            adapter (Adapter): The adapter in which the function should be executed.
+            message: (AnyStr): The message to be handled.
+
+        Returns:
+            Tuple[AsyncIterable[Union[str, bytes]], bool]:
+                A tuple of the asynchronous iterable of a single reply message and a
+                flag indicating whether an interrupt should be raised by the adapter.
+        """
+        responses, interrupt = await self.interpreter.handle(adapter, message)
+        resp = await self._combine_responses(responses)
+        return resp, interrupt


### PR DESCRIPTION
Requires #89 
Fixes #92 and #93 
Required for #90 

- Allows for `RegexCommand` to parse from data of type `AnyStr` rather than just `bytes`.
- `RegexCommand.parse` now also returns the start and end indices of the match within the message, as well as the length of the message matched against. This gives enough information for `MultiCommandInterprerter` to strip off a matched command and for `CommandInterpreter` to check for a full match.
- `CommandInterpreter.handle` logic updated to use the new return signature.
- Tests added for `RegexCommand` and `CommandInterpreter`