### PR TITLE
Ignore empty strings in SplittingInterpreter

### DIFF
--- a/src/tickit/adapters/interpreters/wrappers/splitting_interpreter.py
+++ b/src/tickit/adapters/interpreters/wrappers/splitting_interpreter.py
@@ -87,7 +87,9 @@ class SplittingInterpreter(Interpreter[AnyStr]):
                 indicating whether an interrupt should be raised by the adapter.
         """
         individual_messages = [
-            msg for msg in re.split(self.message_delimiter, message) if msg is not None
+            msg
+            for msg in re.split(self.message_delimiter, message)
+            if msg  # Discard empty strings and None
         ]
 
         results = await self._handle_individual_messages(adapter, individual_messages)

--- a/tests/adapters/interpreters/wrappers/test_splitting_interpreter.py
+++ b/tests/adapters/interpreters/wrappers/test_splitting_interpreter.py
@@ -41,7 +41,7 @@ async def _test_sub_messages(
         (b"foo/bar", b"/", [b"foo", b"bar"]),
         ("single message", "/", ["single message"]),
         ("just1the2words", r"[1-4]", ["just", "the", "words"]),
-        ("#1J=1 #2 P", r"(#[1-8])|\s", ["", "#1", "J=1", "", "#2", "", "P"]),
+        ("#1J=1 #2 P", r"(#[1-8])|\s", ["#1", "J=1", "#2", "P"]),
     ],
 )
 @patch.object(DummySplittingInterpreter, "_collect_responses")
@@ -148,7 +148,7 @@ async def test_handles_empty_messages_correctly(
 
     await splitting_interpreter.handle(AsyncMock(), "")
 
-    mock_handle_individual_messages.assert_called_once_with(ANY, [""])
+    mock_handle_individual_messages.assert_called_once_with(ANY, [])
 
 
 @pytest.mark.parametrize(
@@ -171,4 +171,4 @@ async def test_delimiter_only_message_results_in_empty_messages_handled(
 
     await splitting_interpreter.handle(AsyncMock(), message)
 
-    mock_handle_individual_messages.assert_called_once_with(ANY, ["", ""])
+    mock_handle_individual_messages.assert_called_once_with(ANY, [])


### PR DESCRIPTION
The splitting originally did behave like this but was modified. It is not clear what the use case for empty strings would be and this behaviour prevents further work to integrate PMAC.