### PR TITLE
Fix type errors caught by pyright but not mypy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,8 +79,8 @@ it increments.
     class CounterDevice(Device):
         """A simple device which increments a value."""
 
-        Inputs: TypedDict = TypedDict("Inputs", {})
-        Outputs: TypedDict = TypedDict("Outputs", {"value":int})
+        Inputs: type = TypedDict("Inputs", {})
+        Outputs: type = TypedDict("Outputs", {"value":int})
 
         def __init__(self, initial_value: int = 0, callback_period: int = int(1e9)) -> None:
             self._value = initial_value

--- a/README.rst
+++ b/README.rst
@@ -79,8 +79,11 @@ it increments.
     class CounterDevice(Device):
         """A simple device which increments a value."""
 
-        Inputs: type = TypedDict("Inputs", {})
-        Outputs: type = TypedDict("Outputs", {"value":int})
+        class Inputs(TypedDict):
+            ...
+
+        class Outputs(TypedDict):
+            value: int
 
         def __init__(self, initial_value: int = 0, callback_period: int = int(1e9)) -> None:
             self._value = initial_value

--- a/docs/user/explanations/devices.rst
+++ b/docs/user/explanations/devices.rst
@@ -18,9 +18,11 @@ values and requests to be called back for an update sometime later.
     """A trivial toy device which produced a random output and requests a callback."""
 
         #: An empty typed mapping of device inputs
-        Inputs: type = TypedDict("Inputs", {})
+        class Inputs(TypedDict):
+            ...
         #: A typed mapping containing the 'output' output value
-        Outputs: type = TypedDict("Outputs", {"output": int})
+        class Outputs(TypedDict):
+            output: int
 
         def __init__(self, callback_period: int = int(1e9)) -> None:
             self.callback_period = SimTime(callback_period)

--- a/docs/user/explanations/devices.rst
+++ b/docs/user/explanations/devices.rst
@@ -18,9 +18,9 @@ values and requests to be called back for an update sometime later.
     """A trivial toy device which produced a random output and requests a callback."""
 
         #: An empty typed mapping of device inputs
-        Inputs: TypedDict = TypedDict("Inputs", {})
+        Inputs: type = TypedDict("Inputs", {})
         #: A typed mapping containing the 'output' output value
-        Outputs: TypedDict = TypedDict("Outputs", {"output": int})
+        Outputs: type = TypedDict("Outputs", {"output": int})
 
         def __init__(self, callback_period: int = int(1e9)) -> None:
             self.callback_period = SimTime(callback_period)

--- a/docs/user/how-to/use-epics-adapter.rst
+++ b/docs/user/how-to/use-epics-adapter.rst
@@ -55,8 +55,10 @@ outputs a current.
     class FemtoDevice(Device):
         """Electronic signal amplifier."""
 
-        Inputs: type = TypedDict("Inputs", {"input": float})
-        Outputs: type = TypedDict("Outputs", {"current": float})
+        class Inputs(TypedDict):
+            input: float
+        class Outputs(TypedDict):
+            current: float
 
         def __init__(
             self,

--- a/docs/user/how-to/use-epics-adapter.rst
+++ b/docs/user/how-to/use-epics-adapter.rst
@@ -55,8 +55,8 @@ outputs a current.
     class FemtoDevice(Device):
         """Electronic signal amplifier."""
 
-        Inputs: TypedDict = TypedDict("Inputs", {"input": float})
-        Outputs: TypedDict = TypedDict("Outputs", {"current": float})
+        Inputs: type = TypedDict("Inputs", {"input": float})
+        Outputs: type = TypedDict("Outputs", {"current": float})
 
         def __init__(
             self,

--- a/docs/user/tutorials/create-a-device.rst
+++ b/docs/user/tutorials/create-a-device.rst
@@ -32,8 +32,10 @@ maps as members. As such we shall put in the following boilerplate.
 
     class AmplifierDevice(Device):
 
-    Inputs: type = TypedDict("Inputs", {})
-    Outputs: type = TypedDict("Outputs", {})
+    class Inputs(TypedDict):
+        ...
+    class Outputs(TypedDict):
+        ...
 
     def __init__(self) -> None:
 
@@ -59,8 +61,10 @@ here.
 
     class AmplifierDevice(Device):
 
-    Inputs: type = TypedDict("Inputs", {})
-    Outputs: type = TypedDict("Outputs", {})
+    class Inputs(TypedDict):
+        ...
+    class Outputs(TypedDict):
+        ...
 
     def __init__(self, initial_amplification: float = 2) -> None:
             self.amplification = initial_amplification
@@ -95,8 +99,10 @@ we define our inputs and outputs in the maps, and the line of logic in the ``upd
 
     class AmplifierDevice(Device):
 
-        Inputs: type = TypedDict("Inputs", {"initial_signal":float})
-        Outputs: type = TypedDict("Outputs", {"amplified_signal":float})
+        class Inputs(TypedDict):
+            initial_signal: float
+        class Outputs(TypedDict):
+            amplified_signal: float
 
         def __init__(self, initial_amplification: float = 2.0) -> None:
             self.amplification = initial_amplification

--- a/docs/user/tutorials/create-a-device.rst
+++ b/docs/user/tutorials/create-a-device.rst
@@ -32,8 +32,8 @@ maps as members. As such we shall put in the following boilerplate.
 
     class AmplifierDevice(Device):
 
-    Inputs: TypedDict = TypedDict("Inputs", {})
-    Outputs: TypedDict = TypedDict("Outputs", {})
+    Inputs: type = TypedDict("Inputs", {})
+    Outputs: type = TypedDict("Outputs", {})
 
     def __init__(self) -> None:
 
@@ -59,8 +59,8 @@ here.
 
     class AmplifierDevice(Device):
 
-    Inputs: TypedDict = TypedDict("Inputs", {})
-    Outputs: TypedDict = TypedDict("Outputs", {})
+    Inputs: type = TypedDict("Inputs", {})
+    Outputs: type = TypedDict("Outputs", {})
 
     def __init__(self, initial_amplification: float = 2) -> None:
             self.amplification = initial_amplification
@@ -95,8 +95,8 @@ we define our inputs and outputs in the maps, and the line of logic in the ``upd
 
     class AmplifierDevice(Device):
 
-        Inputs: TypedDict = TypedDict("Inputs", {"initial_signal":float})
-        Outputs: TypedDict = TypedDict("Outputs", {"amplified_signal":float})
+        Inputs: type = TypedDict("Inputs", {"initial_signal":float})
+        Outputs: type = TypedDict("Outputs", {"amplified_signal":float})
 
         def __init__(self, initial_amplification: float = 2.0) -> None:
             self.amplification = initial_amplification

--- a/examples/devices/amplifier.py
+++ b/examples/devices/amplifier.py
@@ -15,8 +15,11 @@ from tickit.utils.byte_format import ByteFormat
 class AmplifierDevice(Device):
     """Amplifier device which multiplies an input signal by an amplification value."""
 
-    Inputs: type = TypedDict("Inputs", {"initial_signal": float})
-    Outputs: type = TypedDict("Outputs", {"amplified_signal": float})
+    class Inputs(TypedDict):
+        initial_signal: float
+
+    class Outputs(TypedDict):
+        amplified_signal: float
 
     def __init__(self, initial_amplification: float = 2) -> None:
         """Amplifier constructor which configures the initial amplification.

--- a/examples/devices/amplifier.py
+++ b/examples/devices/amplifier.py
@@ -15,8 +15,8 @@ from tickit.utils.byte_format import ByteFormat
 class AmplifierDevice(Device):
     """Amplifier device which multiplies an input signal by an amplification value."""
 
-    Inputs: TypedDict = TypedDict("Inputs", {"initial_signal": float})
-    Outputs: TypedDict = TypedDict("Outputs", {"amplified_signal": float})
+    Inputs: type = TypedDict("Inputs", {"initial_signal": float})
+    Outputs: type = TypedDict("Outputs", {"amplified_signal": float})
 
     def __init__(self, initial_amplification: float = 2) -> None:
         """Amplifier constructor which configures the initial amplification.

--- a/examples/devices/counter.py
+++ b/examples/devices/counter.py
@@ -23,9 +23,9 @@ class CounterDevice(Device):
     """A simple device which increments a value."""
 
     #: An empty typed mapping of input values
-    Inputs: TypedDict = TypedDict("Inputs", {})
+    Inputs: type = TypedDict("Inputs", {})
     #: A typed mapping containing the 'value' output value
-    Outputs: TypedDict = TypedDict("Outputs", {"value": int})
+    Outputs: type = TypedDict("Outputs", {"value": int})
 
     def __init__(self, initial_value: int = 0, callback_period: int = int(1e9)) -> None:
         """A constructor of the counter, which increments the input value.

--- a/examples/devices/counter.py
+++ b/examples/devices/counter.py
@@ -23,9 +23,12 @@ class CounterDevice(Device):
     """A simple device which increments a value."""
 
     #: An empty typed mapping of input values
-    Inputs: type = TypedDict("Inputs", {})
+    class Inputs(TypedDict):
+        ...
+
     #: A typed mapping containing the 'value' output value
-    Outputs: type = TypedDict("Outputs", {"value": int})
+    class Outputs(TypedDict):
+        value: int
 
     def __init__(self, initial_value: int = 0, callback_period: int = int(1e9)) -> None:
         """A constructor of the counter, which increments the input value.

--- a/examples/devices/isolated_device.py
+++ b/examples/devices/isolated_device.py
@@ -21,8 +21,11 @@ class IsolatedBoxDevice(Device):
     The device has no inputs or outputs and interacts solely through adapters.
     """
 
-    Inputs: type = TypedDict("Inputs", {})
-    Outputs: type = TypedDict("Outputs", {})
+    class Inputs(TypedDict):
+        ...
+
+    class Outputs(TypedDict):
+        ...
 
     def __init__(self, initial_value: float = 2) -> None:
         """Constructor which configures the initial value

--- a/examples/devices/isolated_device.py
+++ b/examples/devices/isolated_device.py
@@ -21,8 +21,8 @@ class IsolatedBoxDevice(Device):
     The device has no inputs or outputs and interacts solely through adapters.
     """
 
-    Inputs: TypedDict = TypedDict("Inputs", {})
-    Outputs: TypedDict = TypedDict("Outputs", {})
+    Inputs: type = TypedDict("Inputs", {})
+    Outputs: type = TypedDict("Outputs", {})
 
     def __init__(self, initial_value: float = 2) -> None:
         """Constructor which configures the initial value

--- a/examples/devices/remote_controlled.py
+++ b/examples/devices/remote_controlled.py
@@ -22,9 +22,12 @@ class RemoteControlledDevice(Device):
     """A trivial toy device which is controlled by an adapter."""
 
     #: An empty typed mapping of device inputs
-    Inputs: type = TypedDict("Inputs", {})
+    class Inputs(TypedDict):
+        ...
+
     #: A typed mapping containing the 'observed' output value
-    Outputs: type = TypedDict("Outputs", {"observed": float})
+    class Outputs(TypedDict):
+        observed: float
 
     def __init__(
         self,

--- a/examples/devices/remote_controlled.py
+++ b/examples/devices/remote_controlled.py
@@ -22,9 +22,9 @@ class RemoteControlledDevice(Device):
     """A trivial toy device which is controlled by an adapter."""
 
     #: An empty typed mapping of device inputs
-    Inputs: TypedDict = TypedDict("Inputs", {})
+    Inputs: type = TypedDict("Inputs", {})
     #: A typed mapping containing the 'observed' output value
-    Outputs: TypedDict = TypedDict("Outputs", {"observed": float})
+    Outputs: type = TypedDict("Outputs", {"observed": float})
 
     def __init__(
         self,

--- a/examples/devices/shutter.py
+++ b/examples/devices/shutter.py
@@ -24,9 +24,9 @@ class ShutterDevice(Device):
     """
 
     #: A typed mapping containing the 'flux' input value
-    Inputs: TypedDict = TypedDict("Inputs", {"flux": float})
+    Inputs: type = TypedDict("Inputs", {"flux": float})
     #: A typed mapping containing the 'flux' output value
-    Outputs: TypedDict = TypedDict("Outputs", {"flux": float})
+    Outputs: type = TypedDict("Outputs", {"flux": float})
 
     def __init__(
         self, default_position: float, initial_position: Optional[float] = None

--- a/examples/devices/shutter.py
+++ b/examples/devices/shutter.py
@@ -24,9 +24,12 @@ class ShutterDevice(Device):
     """
 
     #: A typed mapping containing the 'flux' input value
-    Inputs: type = TypedDict("Inputs", {"flux": float})
+    class Inputs(TypedDict):
+        flux: float
+
     #: A typed mapping containing the 'flux' output value
-    Outputs: type = TypedDict("Outputs", {"flux": float})
+    class Outputs(TypedDict):
+        flux: float
 
     def __init__(
         self, default_position: float, initial_position: Optional[float] = None

--- a/examples/devices/trampoline.py
+++ b/examples/devices/trampoline.py
@@ -16,9 +16,12 @@ class TrampolineDevice(Device):
     """A trivial toy device which requests a callback every update."""
 
     #: An empty typed mapping of device inputs
-    Inputs: type = TypedDict("Inputs", {})
+    class Inputs(TypedDict):
+        ...
+
     #: An empty typed mapping of device outputs
-    Outputs: type = TypedDict("Outputs", {})
+    class Outputs(TypedDict):
+        ...
 
     def __init__(self, callback_period: int = int(1e9)) -> None:
         """A constructor of the sink which configures the device callback period.
@@ -55,9 +58,12 @@ class RandomTrampolineDevice(Device):
     """A trivial toy device which produced a random output and requests a callback."""
 
     #: An empty typed mapping of device inputs
-    Inputs: type = TypedDict("Inputs", {})
+    class Inputs(TypedDict):
+        ...
+
     #: A typed mapping containing the 'output' output value
-    Outputs: type = TypedDict("Outputs", {"output": int})
+    class Outputs(TypedDict):
+        output: int
 
     def __init__(self, callback_period: int = int(1e9)) -> None:
         """A constructor of the sink which configures the device callback period.

--- a/examples/devices/trampoline.py
+++ b/examples/devices/trampoline.py
@@ -16,9 +16,9 @@ class TrampolineDevice(Device):
     """A trivial toy device which requests a callback every update."""
 
     #: An empty typed mapping of device inputs
-    Inputs: TypedDict = TypedDict("Inputs", {})
+    Inputs: type = TypedDict("Inputs", {})
     #: An empty typed mapping of device outputs
-    Outputs: TypedDict = TypedDict("Outputs", {})
+    Outputs: type = TypedDict("Outputs", {})
 
     def __init__(self, callback_period: int = int(1e9)) -> None:
         """A constructor of the sink which configures the device callback period.
@@ -55,9 +55,9 @@ class RandomTrampolineDevice(Device):
     """A trivial toy device which produced a random output and requests a callback."""
 
     #: An empty typed mapping of device inputs
-    Inputs: TypedDict = TypedDict("Inputs", {})
+    Inputs: type = TypedDict("Inputs", {})
     #: A typed mapping containing the 'output' output value
-    Outputs: TypedDict = TypedDict("Outputs", {"output": int})
+    Outputs: type = TypedDict("Outputs", {"output": int})
 
     def __init__(self, callback_period: int = int(1e9)) -> None:
         """A constructor of the sink which configures the device callback period.

--- a/examples/devices/zeromq_push_device.py
+++ b/examples/devices/zeromq_push_device.py
@@ -23,7 +23,7 @@ class IoBoxZeroMqAdapter(ZeroMqPushAdapter):
         self,
         host: str = "127.0.0.1",
         port: int = 5555,
-        socket_factory: Optional[SocketFactory] = create_zmq_push_socket,
+        socket_factory: SocketFactory = create_zmq_push_socket,
         addresses_to_publish: Optional[Set[str]] = None,
     ) -> None:
         super().__init__(host, port, socket_factory)
@@ -32,7 +32,7 @@ class IoBoxZeroMqAdapter(ZeroMqPushAdapter):
     def after_update(self):
         for address in self._addresses_to_publish:
             value = self.device.read(address)
-            self.send_message([{address: value}])
+            _ = self.send_message([{address: value}])
 
 
 @pydantic.v1.dataclasses.dataclass

--- a/src/tickit/adapters/epicsadapter/adapter.py
+++ b/src/tickit/adapters/epicsadapter/adapter.py
@@ -73,14 +73,15 @@ class EpicsAdapter(Adapter):
 
     def load_records_without_DTYP_fields(self):
         """Load records from database file without DTYP fields."""
-        with open(self.db_file, "rb") as inp:
-            with NamedTemporaryFile(suffix=".db", delete=False) as out:
-                for line in inp.readlines():
-                    if not re.match(rb"\s*field\s*\(\s*DTYP", line):
-                        out.write(line)
+        if self.db_file:
+            with open(self.db_file, "rb") as inp:
+                with NamedTemporaryFile(suffix=".db", delete=False) as out:
+                    for line in inp.readlines():
+                        if not re.match(rb"\s*field\s*\(\s*DTYP", line):
+                            out.write(line)
 
-        softioc.dbLoadDatabase(out.name, substitutions=f"device={self.ioc_name}")
-        os.unlink(out.name)
+            softioc.dbLoadDatabase(out.name, substitutions=f"device={self.ioc_name}")
+            os.unlink(out.name)
 
     async def run_forever(
         self, device: Device, raise_interrupt: RaiseInterrupt

--- a/src/tickit/adapters/epicsadapter/ioc_manager.py
+++ b/src/tickit/adapters/epicsadapter/ioc_manager.py
@@ -63,5 +63,5 @@ def _build_and_run_ioc() -> None:
     # dbl directly prints out all record names, so we have to check
     # the log level in order to only do it in DEBUG.
     if LOGGER.level <= logging.DEBUG:
-        softioc.dbl() # type: ignore
+        softioc.dbl()  # type: ignore
     LOGGER.debug("IOC started")

--- a/src/tickit/adapters/epicsadapter/ioc_manager.py
+++ b/src/tickit/adapters/epicsadapter/ioc_manager.py
@@ -63,5 +63,5 @@ def _build_and_run_ioc() -> None:
     # dbl directly prints out all record names, so we have to check
     # the log level in order to only do it in DEBUG.
     if LOGGER.level <= logging.DEBUG:
-        softioc.dbl()
+        softioc.dbl() # type: ignore
     LOGGER.debug("IOC started")

--- a/src/tickit/adapters/interpreters/command/command_interpreter.py
+++ b/src/tickit/adapters/interpreters/command/command_interpreter.py
@@ -2,6 +2,7 @@ from abc import abstractmethod
 from inspect import getmembers
 from typing import (
     AnyStr,
+    AsyncIterator,
     Optional,
     Protocol,
     Sequence,
@@ -82,5 +83,13 @@ class CommandInterpreter(Interpreter[AnyStr]):
             if not isinstance(resp, AsyncIterator):
                 resp = wrap_as_async_iterator(resp)
             return resp, command.interrupt
-        resp = CommandInterpreter.unknown_command()
-        return resp, False
+
+        msg = "Request does not match any known command"
+        # This is a pain but the message needs to match the input message
+        # TODO: Fix command interpreters' handling of bytes vs str
+        if isinstance(message, bytes):
+            resp = wrap_as_async_iterator(msg.encode("utf-8"))
+            return resp, False
+        else:
+            resp = wrap_as_async_iterator(msg)
+            return resp, False

--- a/src/tickit/adapters/interpreters/command/command_interpreter.py
+++ b/src/tickit/adapters/interpreters/command/command_interpreter.py
@@ -2,7 +2,6 @@ from abc import abstractmethod
 from inspect import getmembers
 from typing import (
     AnyStr,
-    AsyncIterable,
     Optional,
     Protocol,
     Sequence,
@@ -11,7 +10,7 @@ from typing import (
     runtime_checkable,
 )
 
-from tickit.adapters.interpreters.utils import wrap_as_async_iterable
+from tickit.adapters.interpreters.utils import wrap_as_async_iterator
 from tickit.core.adapter import Adapter, Interpreter
 
 
@@ -48,26 +47,15 @@ class CommandInterpreter(Interpreter[AnyStr]):
     called with the parsed arguments.
     """
 
-    @staticmethod
-    async def unknown_command() -> AsyncIterable[bytes]:
-        """An asynchronous iterable of containing a single unknown command reply.
-
-        Returns:
-            AsyncIterable[bytes]:
-                An asynchronous iterable of containing a single unknown command reply:
-                "Request does not match any known command".
-        """
-        yield b"Request does not match any known command"
-
     async def handle(
         self, adapter: Adapter, message: AnyStr
-    ) -> Tuple[AsyncIterable[AnyStr], bool]:
+    ) -> Tuple[AsyncIterator[AnyStr], bool]:
         """Matches the message to an adapter command and calls the corresponding method.
 
         An asynchronous method which handles a message by attempting to match the
         message against each of the registered commands, if a match is found the
         corresponding command is called and its reply is returned with an asynchronous
-        iterable wrapper if required. If no match is found the unknown command message
+        iterator wrapper if required. If no match is found the unknown command message
         is returned with no request for interrupt.
 
         Args:
@@ -75,8 +63,8 @@ class CommandInterpreter(Interpreter[AnyStr]):
             message (bytes): The message to be handled.
 
         Returns:
-            Tuple[AsyncIterable[Union[str, bytes]], bool]:
-                A tuple of the asynchronous iterable of reply messages and a flag
+            Tuple[AsyncIterator[Union[str, bytes]], bool]:
+                A tuple of the asynchronous iterator of reply messages and a flag
                 indicating whether an interrupt should be raised by the adapter.
         """
         for _, method in getmembers(adapter):
@@ -91,8 +79,8 @@ class CommandInterpreter(Interpreter[AnyStr]):
                 for arg, argtype in zip(args, get_type_hints(method).values())
             )
             resp = await method(*args)
-            if not isinstance(resp, AsyncIterable):
-                resp = wrap_as_async_iterable(resp)
+            if not isinstance(resp, AsyncIterator):
+                resp = wrap_as_async_iterator(resp)
             return resp, command.interrupt
         resp = CommandInterpreter.unknown_command()
         return resp, False

--- a/src/tickit/adapters/interpreters/command/regex_command.py
+++ b/src/tickit/adapters/interpreters/command/regex_command.py
@@ -27,8 +27,9 @@ class RegexCommand(Generic[AnyStr]):
     convert: Callable[[bytes], AnyStr] = field(init=False)
 
     def __post_init__(self, regex: AnyStr, format: Optional[str]):
-        # The type checking fails here as it can't determine that the return type matches the
-        # regex type. The isinstance should narrow the AnyStr type but doesn't
+        # The type checking fails here as it can't determine that the return
+        # type matches the regex type. The isinstance should narrow the AnyStr
+        # type but doesn't
         if isinstance(regex, str):
             if format is None:
                 raise ValueError(

--- a/src/tickit/adapters/interpreters/command/regex_command.py
+++ b/src/tickit/adapters/interpreters/command/regex_command.py
@@ -1,6 +1,6 @@
 from dataclasses import InitVar, dataclass, field
-from typing import AnyStr, Callable, Generic, Optional, Sequence
 from re import Pattern, compile
+from typing import AnyStr, Callable, Generic, Optional, Sequence
 
 
 @dataclass

--- a/src/tickit/adapters/interpreters/command/regex_command.py
+++ b/src/tickit/adapters/interpreters/command/regex_command.py
@@ -31,10 +31,12 @@ class RegexCommand(Generic[AnyStr]):
         # regex type. The isinstance should narrow the AnyStr type but doesn't
         if isinstance(regex, str):
             if format is None:
-                raise ValueError("If regex is a string, format is required to decode input")
-            self.convert = lambda b: b.decode(format) # type: ignore
+                raise ValueError(
+                    "If regex is a string, format is required to decode input"
+                )
+            self.convert = lambda b: b.decode(format)  # type: ignore
         else:
-            self.convert = lambda b: b # type: ignore
+            self.convert = lambda b: b  # type: ignore
 
         self.pattern = compile(regex)
 

--- a/src/tickit/adapters/interpreters/command/regex_command.py
+++ b/src/tickit/adapters/interpreters/command/regex_command.py
@@ -1,9 +1,9 @@
-import re
-from dataclasses import dataclass
+from dataclasses import InitVar, dataclass, field
 from typing import AnyStr, Callable, Generic, Optional, Sequence
+from re import Pattern, compile
 
 
-@dataclass(frozen=True)
+@dataclass
 class RegexCommand(Generic[AnyStr]):
     """A decorator to register an adapter method as a regex parsed command.
 
@@ -20,9 +20,23 @@ class RegexCommand(Generic[AnyStr]):
             A decorator which registers the adapter method as a message handler.
     """
 
-    regex: AnyStr
+    regex: InitVar[AnyStr]
     interrupt: bool = False
-    format: Optional[str] = None
+    format: InitVar[Optional[str]] = None
+    pattern: Pattern[AnyStr] = field(init=False)
+    convert: Callable[[bytes], AnyStr] = field(init=False)
+
+    def __post_init__(self, regex: AnyStr, format: Optional[str]):
+        # The type checking fails here as it can't determine that the return type matches the
+        # regex type. The isinstance should narrow the AnyStr type but doesn't
+        if isinstance(regex, str):
+            if format is None:
+                raise ValueError("If regex is a string, format is required to decode input")
+            self.convert = lambda b: b.decode(format) # type: ignore
+        else:
+            self.convert = lambda b: b # type: ignore
+
+        self.pattern = compile(regex)
 
     def __call__(self, func: Callable) -> Callable:
         """A decorator which registers the adapter method as a message handler.
@@ -51,9 +65,8 @@ class RegexCommand(Generic[AnyStr]):
                 If a full match is found a sequence of function arguments is returned,
                 otherwise the method returns None.
         """
-        message = data.decode(self.format, "ignore").strip() if self.format else data
-        if isinstance(message, type(self.regex)):
-            match = re.fullmatch(self.regex, message)
-            if match:
-                return match.groups()
+        message = self.convert(data)
+        match = self.pattern.fullmatch(message)
+        if match:
+            return match.groups()
         return None

--- a/src/tickit/adapters/interpreters/utils.py
+++ b/src/tickit/adapters/interpreters/utils.py
@@ -1,28 +1,29 @@
-from typing import AnyStr, AsyncIterable, Iterable
+from collections.abc import AsyncIterator
+from typing import AnyStr, Iterable
 
 
-async def wrap_as_async_iterable(message: AnyStr) -> AsyncIterable[AnyStr]:
-    """Wraps a message in an asynchronous iterable.
+async def wrap_as_async_iterator(message: AnyStr) -> AsyncIterator[AnyStr]:
+    """Wraps a message in an asynchronous iterator.
 
     Args:
         message (AnyStr): A singular message.
 
     Returns:
-        AsyncIterable[AnyStr]: An asynchronous iterable containing the message.
+        AsyncIterator[AnyStr]: An asynchronous iterator containing the message.
     """
     yield message
 
 
-async def wrap_messages_as_async_iterable(
+async def wrap_messages_as_async_iterator(
     messages: Iterable[AnyStr],
-) -> AsyncIterable[AnyStr]:
-    """Wraps a message in an asynchronous iterable.
+) -> AsyncIterator[AnyStr]:
+    """Wraps a message in an asynchronous iterator.
 
     Args:
         message (AnyStr): An iterable containing a number of messages.
 
     Returns:
-        AsyncIterable[AnyStr]: An asynchronous iterable containing the messages.
+        AsyncIterator[AnyStr]: An asynchronous iterator containing the messages.
     """
     for message in messages:
         yield message

--- a/src/tickit/adapters/interpreters/wrappers/joining_interpreter.py
+++ b/src/tickit/adapters/interpreters/wrappers/joining_interpreter.py
@@ -49,7 +49,9 @@ class JoiningInterpreter(Interpreter[AnyStr]):
                 An asynchronous iterable containing a single reply message.
         """
         response_list = [response async for response in responses]
-        response = self.response_delimiter.join(response_list)
+        # type checking AnyStr.join doesn't work for some reason
+        # https://github.com/microsoft/pyright/issues/5556
+        response = self.response_delimiter.join(response_list)  # type: ignore
         return wrap_as_async_iterator(response)
 
     async def handle(

--- a/src/tickit/adapters/interpreters/wrappers/joining_interpreter.py
+++ b/src/tickit/adapters/interpreters/wrappers/joining_interpreter.py
@@ -1,6 +1,6 @@
 from typing import AnyStr, AsyncIterable, Tuple
 
-from tickit.adapters.interpreters.utils import wrap_as_async_iterable
+from tickit.adapters.interpreters.utils import wrap_as_async_iterator
 from tickit.core.adapter import Adapter, Interpreter
 
 
@@ -50,7 +50,7 @@ class JoiningInterpreter(Interpreter[AnyStr]):
         """
         response_list = [response async for response in responses]
         response = self.response_delimiter.join(response_list)
-        return wrap_as_async_iterable(response)
+        return wrap_as_async_iterator(response)
 
     async def handle(
         self, adapter: Adapter, message: AnyStr

--- a/src/tickit/adapters/interpreters/wrappers/splitting_interpreter.py
+++ b/src/tickit/adapters/interpreters/wrappers/splitting_interpreter.py
@@ -1,4 +1,4 @@
-import re
+from re import Pattern, compile
 from typing import AnyStr, AsyncIterable, List, Tuple
 
 from tickit.adapters.interpreters.utils import wrap_messages_as_async_iterator
@@ -27,7 +27,7 @@ class SplittingInterpreter(Interpreter[AnyStr]):
         """
         super().__init__()
         self.interpreter: Interpreter[AnyStr] = interpreter
-        self.message_delimiter: AnyStr = message_delimiter
+        self.delimeter: Pattern[AnyStr] = compile(message_delimiter)
 
     async def _handle_individual_messages(
         self, adapter: Adapter, individual_messages: List[AnyStr]
@@ -89,7 +89,7 @@ class SplittingInterpreter(Interpreter[AnyStr]):
         """
         individual_messages = [
             msg
-            for msg in re.split(self.message_delimiter, message)
+            for msg in self.delimeter.split(message)
             if msg  # Discard empty strings and None
         ]
 

--- a/src/tickit/adapters/interpreters/wrappers/splitting_interpreter.py
+++ b/src/tickit/adapters/interpreters/wrappers/splitting_interpreter.py
@@ -1,7 +1,7 @@
 import re
 from typing import AnyStr, AsyncIterable, List, Tuple
 
-from tickit.adapters.interpreters.utils import wrap_messages_as_async_iterable
+from tickit.adapters.interpreters.utils import wrap_messages_as_async_iterator
 from tickit.core.adapter import Adapter, Interpreter
 
 
@@ -65,7 +65,7 @@ class SplittingInterpreter(Interpreter[AnyStr]):
             async for response in response_gen
         ]
 
-        resp = wrap_messages_as_async_iterable(responses)
+        resp = wrap_messages_as_async_iterator(responses)
         interrupt = any(individual_interrupts)
         return resp, interrupt
 

--- a/src/tickit/adapters/interpreters/wrappers/splitting_interpreter.py
+++ b/src/tickit/adapters/interpreters/wrappers/splitting_interpreter.py
@@ -62,7 +62,8 @@ class SplittingInterpreter(Interpreter[AnyStr]):
         responses = [
             response
             for response_gen in individual_responses
-            async for response in response_gen
+            # type checking can't figure out the return types of zip(*args)
+            async for response in response_gen  # type: ignore
         ]
 
         resp = wrap_messages_as_async_iterator(responses)

--- a/src/tickit/core/state_interfaces/kafka.py
+++ b/src/tickit/core/state_interfaces/kafka.py
@@ -43,7 +43,8 @@ class KafkaStateConsumer(Generic[C]):
         await self.consumer.start()
         while True:
             async for message in self.consumer:
-                await self.callback(message.value)
+                if message.value is not None:
+                    await self.callback(message.value)
 
     async def subscribe(self, topics: Iterable[str]):
         """Subscribes the consumer to the given topics.

--- a/src/tickit/core/state_interfaces/state_interface.py
+++ b/src/tickit/core/state_interfaces/state_interface.py
@@ -73,8 +73,7 @@ class StateProducer(Protocol[P]):
 
 
 #: The union of StateConsumer and StateProducer
-StateInterface = TypeVar("StateInterface", StateConsumer, StateProducer)
-
+StateInterface = TypeVar("StateInterface", bound=Union[StateConsumer, StateProducer])
 
 consumers: Dict[str, Tuple[Type[StateConsumer], bool]] = dict()
 producers: Dict[str, Tuple[Type[StateProducer], bool]] = dict()

--- a/src/tickit/core/state_interfaces/state_interface.py
+++ b/src/tickit/core/state_interfaces/state_interface.py
@@ -8,6 +8,7 @@ from typing import (
     Tuple,
     Type,
     TypeVar,
+    Union,
     runtime_checkable,
 )
 from warnings import warn

--- a/src/tickit/devices/iobox.py
+++ b/src/tickit/devices/iobox.py
@@ -53,11 +53,9 @@ class IoBoxDevice(Device, Generic[A, V]):
     """
 
     #: A typed mapping containing the 'input' input value
-    Inputs: TypedDict = TypedDict(
-        "Inputs", {"updates": NotRequired[List[Tuple[Any, Any]]]}
-    )
-    #: An empty typed mapping of device outputs
-    Outputs: TypedDict = TypedDict(
+    Inputs: type = TypedDict("Inputs", {"updates": NotRequired[List[Tuple[Any, Any]]]})
+    #: A typed mapping of device outputs
+    Outputs: type = TypedDict(
         "Outputs", {"updates": NotRequired[List[Tuple[Any, Any]]]}
     )
 

--- a/src/tickit/devices/iobox.py
+++ b/src/tickit/devices/iobox.py
@@ -53,11 +53,12 @@ class IoBoxDevice(Device, Generic[A, V]):
     """
 
     #: A typed mapping containing the 'input' input value
-    Inputs: type = TypedDict("Inputs", {"updates": NotRequired[List[Tuple[Any, Any]]]})
+    class Inputs(TypedDict):
+        updates: NotRequired[List[Tuple[Any, Any]]]
+
     #: A typed mapping of device outputs
-    Outputs: type = TypedDict(
-        "Outputs", {"updates": NotRequired[List[Tuple[Any, Any]]]}
-    )
+    class Outputs(TypedDict):
+        updates: NotRequired[List[Tuple[Any, Any]]]
 
     _memory: Dict[A, V]
     _change_buffer: List[Tuple[A, V]]

--- a/src/tickit/devices/sink.py
+++ b/src/tickit/devices/sink.py
@@ -15,9 +15,12 @@ class SinkDevice(Device):
     """A simple device which can take any input and produces no output."""
 
     #: A typed mapping containing the 'input' input value
-    Inputs: type = TypedDict("Inputs", {"input": Any})
+    class Inputs(TypedDict):
+        input: Any
+
     #: An empty typed mapping of device outputs
-    Outputs: type = TypedDict("Outputs", {})
+    class Outputs(TypedDict):
+        ...
 
     def update(self, time: SimTime, inputs: Inputs) -> DeviceUpdate[Outputs]:
         """The update method which logs the inputs and produces no outputs.

--- a/src/tickit/devices/sink.py
+++ b/src/tickit/devices/sink.py
@@ -15,9 +15,9 @@ class SinkDevice(Device):
     """A simple device which can take any input and produces no output."""
 
     #: A typed mapping containing the 'input' input value
-    Inputs: TypedDict = TypedDict("Inputs", {"input": Any})
+    Inputs: type = TypedDict("Inputs", {"input": Any})
     #: An empty typed mapping of device outputs
-    Outputs: TypedDict = TypedDict("Outputs", {})
+    Outputs: type = TypedDict("Outputs", {})
 
     def update(self, time: SimTime, inputs: Inputs) -> DeviceUpdate[Outputs]:
         """The update method which logs the inputs and produces no outputs.

--- a/src/tickit/devices/source.py
+++ b/src/tickit/devices/source.py
@@ -15,9 +15,9 @@ class SourceDevice(Device):
     """A simple device which produces a pre-configured value."""
 
     #: An empty typed mapping of device inputs
-    Inputs: TypedDict = TypedDict("Inputs", {})
+    Inputs: type = TypedDict("Inputs", {})
     #: A typed mapping containing the 'value' output value
-    Outputs: TypedDict = TypedDict("Outputs", {"value": Any})
+    Outputs: type = TypedDict("Outputs", {"value": Any})
 
     def __init__(self, value: Any) -> None:
         """A constructor of the source, which takes the pre-configured output value.

--- a/src/tickit/devices/source.py
+++ b/src/tickit/devices/source.py
@@ -15,9 +15,12 @@ class SourceDevice(Device):
     """A simple device which produces a pre-configured value."""
 
     #: An empty typed mapping of device inputs
-    Inputs: type = TypedDict("Inputs", {})
+    class Inputs(TypedDict):
+        ...
+
     #: A typed mapping containing the 'value' output value
-    Outputs: type = TypedDict("Outputs", {"value": Any})
+    class Outputs(TypedDict):
+        value: Any
 
     def __init__(self, value: Any) -> None:
         """A constructor of the source, which takes the pre-configured output value.

--- a/src/tickit/utils/configuration/tagged_union.py
+++ b/src/tickit/utils/configuration/tagged_union.py
@@ -48,7 +48,8 @@ def _as_tagged_union(
         # be identified when deserializing.
         cls.__annotations__ = {
             **getattr(cls, "__annotations__", {}),
-            # Literal is supposed to only accept literal strings but we need to set it dynamically
+            # Literal is supposed to only accept literal strings but we need to
+            # set it dynamically
             discriminator: Literal[cls_name],  # type: ignore
         }
         setattr(cls, discriminator, field(default=cls_name, repr=False))

--- a/src/tickit/utils/configuration/tagged_union.py
+++ b/src/tickit/utils/configuration/tagged_union.py
@@ -48,7 +48,8 @@ def _as_tagged_union(
         # be identified when deserializing.
         cls.__annotations__ = {
             **getattr(cls, "__annotations__", {}),
-            discriminator: Literal[cls_name],
+            # Literal is supposed to only accept literal strings but we need to set it dynamically
+            discriminator: Literal[cls_name], # type: ignore
         }
         setattr(cls, discriminator, field(default=cls_name, repr=False))
 

--- a/src/tickit/utils/configuration/tagged_union.py
+++ b/src/tickit/utils/configuration/tagged_union.py
@@ -49,7 +49,7 @@ def _as_tagged_union(
         cls.__annotations__ = {
             **getattr(cls, "__annotations__", {}),
             # Literal is supposed to only accept literal strings but we need to set it dynamically
-            discriminator: Literal[cls_name], # type: ignore
+            discriminator: Literal[cls_name],  # type: ignore
         }
         setattr(cls, discriminator, field(default=cls_name, repr=False))
 

--- a/tests/adapters/interpreters/command/test_regex_command.py
+++ b/tests/adapters/interpreters/command/test_regex_command.py
@@ -12,7 +12,7 @@ def regex_command(regex: AnyStr, interrupt: bool, format: Optional[str]):
 
 def test_regex_command_registers_command():
     class TestAdapter:
-        @RegexCommand("test")
+        @RegexCommand("test", format="utf-8")
         def test_method():
             pass
 

--- a/tests/adapters/interpreters/endpoints/test_http_endpoint.py
+++ b/tests/adapters/interpreters/endpoints/test_http_endpoint.py
@@ -1,5 +1,7 @@
 import pytest
 from aiohttp import web
+from aiohttp.web_response import StreamResponse
+from mock import Mock
 
 from tickit.adapters.interpreters.endpoints.http_endpoint import HttpEndpoint
 
@@ -27,8 +29,8 @@ def test_http_endpoint_registers_put_endpoint():
     assert isinstance(TestAdapter.test_endpoint.__endpoint__, HttpEndpoint)
 
 
-def fake_endpoint(request: web.Request):
-    pass
+async def fake_endpoint(request: web.Request) -> StreamResponse:
+    return Mock()
 
 
 @pytest.mark.parametrize(

--- a/tests/adapters/interpreters/test_utils.py
+++ b/tests/adapters/interpreters/test_utils.py
@@ -1,15 +1,15 @@
 import pytest
 
 from tickit.adapters.interpreters.utils import (
-    wrap_as_async_iterable,
-    wrap_messages_as_async_iterable,
+    wrap_as_async_iterator,
+    wrap_messages_as_async_iterator,
 )
 
 
 @pytest.mark.asyncio
 async def test_wrap_list_correctly():
     messages = ["Hello", "World"]
-    wrapped = wrap_messages_as_async_iterable(messages)
+    wrapped = wrap_messages_as_async_iterator(messages)
     assert "Hello" == await wrapped.__anext__()
     assert "World" == await wrapped.__anext__()
     with pytest.raises(StopAsyncIteration):
@@ -19,7 +19,7 @@ async def test_wrap_list_correctly():
 @pytest.mark.asyncio
 async def test_wrap_message_correctly():
     message = b"Hello World"
-    wrapped = wrap_as_async_iterable(message)
+    wrapped = wrap_as_async_iterator(message)
     assert b"Hello World" == await wrapped.__anext__()
     with pytest.raises(StopAsyncIteration):
         await wrapped.__anext__()

--- a/tests/adapters/interpreters/wrappers/test_splitting_interpreter.py
+++ b/tests/adapters/interpreters/wrappers/test_splitting_interpreter.py
@@ -108,7 +108,9 @@ async def test_individual_results_combined_correctly(
     (
         _,
         combined_interrupt,
-    ) = await splitting_interpreter._collect_responses(individual_results)
+    ) = await splitting_interpreter._collect_responses(
+        individual_results  # type: ignore
+    )
     mock_wrap_message.assert_called_once_with(individual_messages)
     assert combined_interrupt == expected_combined_interrupt
 
@@ -127,7 +129,7 @@ async def test_multi_resp(
 
     splitting_interpreter = DummySplittingInterpreter(AsyncMock(), " ")
     individual_results = [(multi_resp(["resp1", "resp2"]), True)]
-    await splitting_interpreter._collect_responses(individual_results)
+    await splitting_interpreter._collect_responses(individual_results)  # type: ignore
     mock_wrap_message.assert_called_once_with(["resp1", "resp2"])
 
 

--- a/tests/adapters/interpreters/wrappers/test_splitting_interpreter.py
+++ b/tests/adapters/interpreters/wrappers/test_splitting_interpreter.py
@@ -3,13 +3,13 @@ from typing import AnyStr, AsyncIterable, List, Tuple
 import pytest
 from mock import ANY, AsyncMock, call, patch
 
-from tickit.adapters.interpreters.utils import wrap_as_async_iterable
+from tickit.adapters.interpreters.utils import wrap_as_async_iterator
 from tickit.adapters.interpreters.wrappers import SplittingInterpreter
 from tickit.core.adapter import Adapter
 
 
 async def dummy_response(msg: AnyStr) -> Tuple[AsyncIterable[AnyStr], bool]:
-    return wrap_as_async_iterable(msg), True
+    return wrap_as_async_iterator(msg), True
 
 
 class DummySplittingInterpreter(SplittingInterpreter):
@@ -92,7 +92,7 @@ async def test_handle_individual_messages_makes_correct_handle_calls(sub_message
 )
 @patch(
     "tickit.adapters.interpreters.wrappers."
-    "splitting_interpreter.wrap_messages_as_async_iterable"
+    "splitting_interpreter.wrap_messages_as_async_iterator"
 )
 async def test_individual_results_combined_correctly(
     mock_wrap_message: AsyncMock,
@@ -102,7 +102,7 @@ async def test_individual_results_combined_correctly(
 ):
     splitting_interpreter = DummySplittingInterpreter(AsyncMock(), " ")
     individual_results = [
-        (wrap_as_async_iterable(msg), interrupt)
+        (wrap_as_async_iterator(msg), interrupt)
         for msg, interrupt in zip(individual_messages, individual_interrupts)
     ]
     (
@@ -116,7 +116,7 @@ async def test_individual_results_combined_correctly(
 @pytest.mark.asyncio
 @patch(
     "tickit.adapters.interpreters.wrappers."
-    "splitting_interpreter.wrap_messages_as_async_iterable"
+    "splitting_interpreter.wrap_messages_as_async_iterator"
 )
 async def test_multi_resp(
     mock_wrap_message: AsyncMock,

--- a/tests/adapters/test_epicsadapter/test_epics_adapter.py
+++ b/tests/adapters/test_epicsadapter/test_epics_adapter.py
@@ -55,9 +55,8 @@ def test_epics_adapter_constructor(epics_adapter: EpicsAdapter):
     pass
 
 
-def test_epics_adapter_interrupt_records_empty_on_construct():
-    with pytest.raises(AttributeError):
-        EpicsAdapter.interrupt_records
+def test_epics_adapter_interrupt_records_empty_on_construct(epics_adapter):
+    assert epics_adapter.interrupt_records == {}
 
 
 def test_link_input_on_interrupt(

--- a/tests/adapters/zeromq/test_push_adapter.py
+++ b/tests/adapters/zeromq/test_push_adapter.py
@@ -57,7 +57,7 @@ def mock_socket_factory(
 
 
 @pytest.fixture
-def zeromq_adapter(mock_socket_factory: aiozmq.ZmqStream) -> ZeroMqPushAdapter:
+def zeromq_adapter(mock_socket_factory: SocketFactory) -> ZeroMqPushAdapter:
     return ZeroMqPushAdapter(
         host=_HOST,
         port=_PORT,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,9 +25,9 @@ def tickit_process(request):
         text=True,
     )
     # Wait for IOC to be up
-    while True:
-        if "complete" in proc.stdout.readline():
-            break
+    assert proc.stdout
+    while "complete" not in proc.stdout.readline():
+        pass
     yield proc
     proc.send_signal(signal.SIGINT)
     print(proc.communicate()[0])

--- a/tests/core/components/test_device_simulation.py
+++ b/tests/core/components/test_device_simulation.py
@@ -88,7 +88,7 @@ async def test_device_simulation_run_forever_method(
     ) as mock_all:
         mock_all.return_value = [asyncio.create_task(asyncio.sleep(0))]
         await device_simulation.run_forever(
-            mock_state_consumer_type, mock_state_producer_type
+            mock_state_consumer_type, mock_state_producer_type  # type: ignore
         )
         patch_asyncio_wait.assert_awaited_once_with(mock_all.return_value)
 

--- a/tests/core/management/test_event_router.py
+++ b/tests/core/management/test_event_router.py
@@ -100,23 +100,23 @@ def event_router(wiring):
 
 def test_wiring_unknown_out_dev(wiring_struct_4_1):
     wiring = Wiring(wiring_struct_4_1)
-    assert dict() == wiring["Out3"]
+    assert dict() == wiring[ComponentID("Out3")]
 
 
 def test_wiring_unknown_out_io(wiring_struct_4_1):
     wiring = Wiring(wiring_struct_4_1)
-    assert set() == wiring["Out1"]["Out1>2"]
+    assert set() == wiring[ComponentID("Out1")][PortID("Out1>2")]
 
 
 def test_inverse_wiring_unknown_in_dev(inverse_wiring_struct_4_1):
     inverse_wiring = InverseWiring(inverse_wiring_struct_4_1)
-    assert dict() == inverse_wiring["In2"]
+    assert dict() == inverse_wiring[ComponentID("In2")]
 
 
 def test_inverse_wiring_unknown_in_io(inverse_wiring_struct_4_1):
     inverse_wiring = InverseWiring(inverse_wiring_struct_4_1)
     with pytest.raises(KeyError):
-        inverse_wiring["In1"]["In1<3"]
+        inverse_wiring[ComponentID("In1")][PortID("In1<3")]
 
 
 def test_event_router_component_tree(event_router: EventRouter):

--- a/tests/core/state_interfaces/test_state_interface.py
+++ b/tests/core/state_interfaces/test_state_interface.py
@@ -58,7 +58,8 @@ def test_add_both_adds_to_interfaces(TestStateConsumer, TestStateProducer):
 
 def test_add_non_interface_warns():
     with pytest.warns(RuntimeWarning):
-        add("Test", False)(type("TestClass", tuple(), dict()))
+        # ignore intentionally wrong type
+        add("Test", False)(type("TestClass", (), {}))  # type: ignore
 
 
 def test_get_returns_consumer(TestStateConsumer, TestStateProducer):

--- a/tests/devices/test_iobox.py
+++ b/tests/devices/test_iobox.py
@@ -29,7 +29,7 @@ def test_writes_pending_until_update(box: IoBoxDevice[int, Any]) -> None:
 def test_outputs_change(box: IoBoxDevice[int, Any]) -> None:
     box.write(4, "foo")
     update = box.update(SimTime(0), {})
-    assert 'updates' in update.outputs
+    assert "updates" in update.outputs
     assert update.outputs["updates"] == [(4, "foo")]
 
 
@@ -38,7 +38,7 @@ def test_outputs_only_last_changes(box: IoBoxDevice[int, Any]) -> None:
     box.update(SimTime(0), {})
     box.write(3, "bar")
     update = box.update(SimTime(0), {})
-    assert 'updates' in update.outputs
+    assert "updates" in update.outputs
     assert update.outputs["updates"] == [(3, "bar")]
 
 
@@ -49,5 +49,5 @@ def test_writes_input(box: IoBoxDevice[int, Any]) -> None:
 
 def test_propagates_input(box: IoBoxDevice[int, Any]) -> None:
     update = box.update(SimTime(0), {"updates": [(4, "foo")]})
-    assert 'updates' in update.outputs
+    assert "updates" in update.outputs
     assert update.outputs["updates"] == [(4, "foo")]

--- a/tests/devices/test_iobox.py
+++ b/tests/devices/test_iobox.py
@@ -29,6 +29,7 @@ def test_writes_pending_until_update(box: IoBoxDevice[int, Any]) -> None:
 def test_outputs_change(box: IoBoxDevice[int, Any]) -> None:
     box.write(4, "foo")
     update = box.update(SimTime(0), {})
+    assert 'updates' in update.outputs
     assert update.outputs["updates"] == [(4, "foo")]
 
 
@@ -37,6 +38,7 @@ def test_outputs_only_last_changes(box: IoBoxDevice[int, Any]) -> None:
     box.update(SimTime(0), {})
     box.write(3, "bar")
     update = box.update(SimTime(0), {})
+    assert 'updates' in update.outputs
     assert update.outputs["updates"] == [(3, "bar")]
 
 
@@ -47,4 +49,5 @@ def test_writes_input(box: IoBoxDevice[int, Any]) -> None:
 
 def test_propagates_input(box: IoBoxDevice[int, Any]) -> None:
     update = box.update(SimTime(0), {"updates": [(4, "foo")]})
+    assert 'updates' in update.outputs
     assert update.outputs["updates"] == [(4, "foo")]

--- a/tests/utils/test_topic_naming.py
+++ b/tests/utils/test_topic_naming.py
@@ -1,6 +1,6 @@
 import pytest
-from tickit.core.typedefs import ComponentID
 
+from tickit.core.typedefs import ComponentID
 from tickit.utils.topic_naming import input_topic, output_topic
 
 

--- a/tests/utils/test_topic_naming.py
+++ b/tests/utils/test_topic_naming.py
@@ -1,21 +1,22 @@
 import pytest
+from tickit.core.typedefs import ComponentID
 
 from tickit.utils.topic_naming import input_topic, output_topic
 
 
 def test_input_affixes():
-    assert "tickit-my_device-in" == input_topic("my_device")
+    assert "tickit-my_device-in" == input_topic(ComponentID("my_device"))
 
 
 def test_input_raises_empty():
     with pytest.raises(ValueError):
-        input_topic("")
+        input_topic(ComponentID(""))
 
 
 def test_output_affixes():
-    assert "tickit-my_device-out" == output_topic("my_device")
+    assert "tickit-my_device-out" == output_topic(ComponentID("my_device"))
 
 
 def test_output_raises_empty():
     with pytest.raises(ValueError):
-        output_topic("")
+        output_topic(ComponentID(""))


### PR DESCRIPTION
- Use `type` as type of Inputs/Outputs fields
- Use correct types instead of string literals in tests
- Use Iterator instead of Iterable as the return type when wrapping
- Check optional keys are present before access
- Ignore type checking of dynamic softioc dbl method
- Strengthen type handling of strings vs bytes in interpreters/adapters

Where type checking has been ignored, comments have been added to explain
why the code is still valid.
