### PR TITLE
Remove codecov patch requirement

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,4 @@ coverage:
       default:
         target: 90%    # the required coverage value
         threshold: 2%  # the leniency in hitting the target
+    patch: false


### PR DESCRIPTION
Removing the CI requirement to maintain a given patch percentage.