### PR TITLE
modify parameters passed to asyncio.wait to avoid deprecation warning.

### DIFF
--- a/src/tickit/core/management/schedulers/master.py
+++ b/src/tickit/core/management/schedulers/master.py
@@ -88,7 +88,7 @@ class MasterScheduler(BaseScheduler):
         assert when is not None
         self.new_wakeup.clear()
 
-        current: asyncio.Future = asyncio.sleep(self.sleep_time(when))
+        current = asyncio.create_task(asyncio.sleep(self.sleep_time(when)))
         new = asyncio.create_task(self.new_wakeup.wait())
         which, _ = await asyncio.wait(
             [current, new], return_when=asyncio.tasks.FIRST_COMPLETED

--- a/src/tickit/core/management/schedulers/master.py
+++ b/src/tickit/core/management/schedulers/master.py
@@ -88,8 +88,8 @@ class MasterScheduler(BaseScheduler):
         assert when is not None
         self.new_wakeup.clear()
 
-        current = asyncio.create_task(asyncio.sleep(self.sleep_time(when)))
         new = asyncio.create_task(self.new_wakeup.wait())
+        current = asyncio.create_task(asyncio.sleep(self.sleep_time(when)))
         which, _ = await asyncio.wait(
             [current, new], return_when=asyncio.tasks.FIRST_COMPLETED
         )


### PR DESCRIPTION
Remove asyncio.wait deprecation warning by only passing tasks to it.

In the master scheduler _do_task method, a coroutine is passed to asyncio.wait. This is deprecated behaviour. I noticed this while working on #153:

```
File "/workspace/tickit/src/tickit/core/management/schedulers/master.py", line 102, in _do_tick
    which, _ = await asyncio.wait(
  File "/usr/local/lib/python3.10/asyncio/tasks.py", line 377, in wait
    warnings.warn("The explicit passing of coroutine objects to "
DeprecationWarning: The explicit passing of coroutine objects to asyncio.wait() is deprecated since Python 3.8, and scheduled for removal in Python 3.11.
```