### PR TITLE
Catch HTTP adapter run_forever failures in test fixture

### DIFF
--- a/tests/adapters/test_httpadapter.py
+++ b/tests/adapters/test_httpadapter.py
@@ -106,6 +106,8 @@ async def adapter_task(
         if exception is not None:
             raise exception
 
+        raise Exception("adapter.run_forever should not finish without an exception")
+
     yield adapter_running
     await adapter.stop()
     await asyncio.wait_for(adapter_running, timeout=10.0)

--- a/tests/adapters/test_httpadapter.py
+++ b/tests/adapters/test_httpadapter.py
@@ -101,7 +101,6 @@ async def adapter_task(
         [adapter_running, adapter_ready], return_when=asyncio.tasks.FIRST_COMPLETED
     )
 
-    # if the adapter_running task is in done, then we extract that exception and raise it;
     if adapter_running in done:
         exception = adapter_running.exception()
         if exception is not None:


### PR DESCRIPTION
Currently on master, running pytest if port 8080 on localhost is bound freezes the output. The terminal simply hangs. I have investigated the issue and fixed this by changing the fixture where this is happening so that it keeps track of the task that calls `.run_forever` on the adaptor as well as `.wait_until_ready` and waits until one of those completes.

wait_until_ready will only ever be set if run_forever gets far enough to set it; if, for example, the server cannot be instantiated, this fails silently, and wait_until_ready therefore waits forever.