### PR TITLE
Remove click pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "pyzmq",
     "softioc",
     "typing_extensions",
-    "click",
+    "click!=8.1.4,!=8.1.5", #https://github.com/pallets/click/issues/2558
 
 ] # Add project dependencies here, e.g. ["click", "numpy"]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "pyzmq",
     "softioc",
     "typing_extensions",
-    "click==8.1.3",
+    "click",
 
 ] # Add project dependencies here, e.g. ["click", "numpy"]
 dynamic = ["version"]


### PR DESCRIPTION
The latest version of click addresses the typing issues of click.group() meaning we should be able to unpin it now.