### PR TITLE
Strip whitespace from regex command input

### DIFF
--- a/src/tickit/adapters/interpreters/command/regex_command.py
+++ b/src/tickit/adapters/interpreters/command/regex_command.py
@@ -35,7 +35,7 @@ class RegexCommand(Generic[AnyStr]):
                 raise ValueError(
                     "If regex is a string, format is required to decode input"
                 )
-            self.convert = lambda b: b.decode(format)  # type: ignore
+            self.convert = lambda b: b.decode(format).strip()  # type: ignore
         else:
             self.convert = lambda b: b  # type: ignore
 

--- a/tests/adapters/interpreters/command/test_regex_command.py
+++ b/tests/adapters/interpreters/command/test_regex_command.py
@@ -45,6 +45,8 @@ def test_regex_command_parse_unmatched_returns_none(
         ),
         (b"\\x01", False, None, b"\x01", tuple()),
         (b"\\x01(.)", False, None, b"\x01\x02", (b"\x02",)),
+        (r"Test\((\d)\)", False, "utf-8", "Test(4)\n".encode("utf-8"), ("4",)),
+        (r"Test\((\d)\)", False, "utf-8", "Test(3)\r\n".encode("utf-8"), ("3",)),
     ],
 )
 def test_regex_command_parse_match_returns_args(


### PR DESCRIPTION
Returns to expected behaviour of regex command interpreter stripping white space.