### PR TITLE
Add manual http interrupt for eiger trigger

### DIFF
--- a/src/tickit/adapters/http.py
+++ b/src/tickit/adapters/http.py
@@ -2,10 +2,13 @@ from inspect import getmembers
 from typing import Callable, Iterable, Tuple
 
 from tickit.adapters.specifications import HttpEndpoint
+from tickit.core.adapter import RaiseInterrupt
 
 
 class HttpAdapter:
     """An adapter interface for the HttpIo."""
+
+    interrupt: RaiseInterrupt
 
     def get_endpoints(self) -> Iterable[Tuple[HttpEndpoint, Callable]]:
         """Returns list of endpoints.

--- a/src/tickit/adapters/io/http_io.py
+++ b/src/tickit/adapters/io/http_io.py
@@ -38,6 +38,7 @@ class HttpIo(AdapterIo[HttpAdapter]):
     async def setup(
         self, adapter: HttpAdapter, raise_interrupt: RaiseInterrupt
     ) -> None:
+        adapter.interrupt = raise_interrupt
         self._ensure_stopped_event().clear()
         endpoints = adapter.get_endpoints()
         await self._start_server(endpoints, raise_interrupt)


### PR DESCRIPTION
The eiger in tickit-devices needs a manual handle to component interrupts for its trigger. This will enable that.