### PR TITLE
Ignore generated file in pyright check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ write_to = "src/tickit/_version.py"
 
 [tool.pyright]
 reportMissingImports = false # Ignore missing stubs in imported modules
+ignore = ["src/tickit/_version.py"]
 
 [tool.isort]
 float_to_top = true


### PR DESCRIPTION
Pyright is checking files generated by setuptools_scm which have outdated annotations in them. This file doesn't need checking so I have included an ignore for it.