### PR TITLE
Added optional separator argument to TcpIo constructor

### DIFF
--- a/src/tickit/adapters/io/tcp_io.py
+++ b/src/tickit/adapters/io/tcp_io.py
@@ -20,7 +20,7 @@ class TcpIo(AdapterIo[CommandAdapter]):
     host: str
     port: int
 
-    def __init__(self, host: str, port: int, separator: str = None) -> None:
+    def __init__(self, host: str, port: int, separator: str | None = None) -> None:
         self.host = host
         self.port = port
         self.separator = separator

--- a/src/tickit/adapters/io/tcp_io.py
+++ b/src/tickit/adapters/io/tcp_io.py
@@ -81,7 +81,9 @@ class TcpIo(AdapterIo[CommandAdapter]):
 
             while True:
                 if self.separator is not None:
-                    data: bytes = await reader.readuntil(separator=self.separator.encode())
+                    data: bytes = ( 
+                        await reader.readuntil(separator=self.separator.encode())
+                    )
                 else:
                     data: bytes = await reader.read(1024)
 

--- a/src/tickit/adapters/io/tcp_io.py
+++ b/src/tickit/adapters/io/tcp_io.py
@@ -20,10 +20,10 @@ class TcpIo(AdapterIo[CommandAdapter]):
     host: str
     port: int
 
-    def __init__(self, host: str, port: int, separator: str | None = None) -> None:
+    def __init__(self, host: str, port: int, terminator: str | None = None) -> None:
         self.host = host
         self.port = port
-        self.separator = separator
+        self.terminator = terminator
 
     async def setup(
         self, adapter: CommandAdapter, raise_interrupt: RaiseInterrupt
@@ -80,9 +80,9 @@ class TcpIo(AdapterIo[CommandAdapter]):
             tasks.append(asyncio.create_task(reply(on_connect())))
 
             while True:
-                if self.separator is not None:
+                if self.terminator is not None:
                     data: bytes = ( 
-                        await reader.readuntil(separator=self.separator.encode())
+                        await reader.readuntil(separator=self.terminator.encode())
                     )
                 else:
                     data: bytes = await reader.read(1024)

--- a/src/tickit/adapters/io/tcp_io.py
+++ b/src/tickit/adapters/io/tcp_io.py
@@ -20,9 +20,10 @@ class TcpIo(AdapterIo[CommandAdapter]):
     host: str
     port: int
 
-    def __init__(self, host: str, port: int) -> None:
+    def __init__(self, host: str, port: int, separator: str = None) -> None:
         self.host = host
         self.port = port
+        self.separator = separator
 
     async def setup(
         self, adapter: CommandAdapter, raise_interrupt: RaiseInterrupt
@@ -79,7 +80,11 @@ class TcpIo(AdapterIo[CommandAdapter]):
             tasks.append(asyncio.create_task(reply(on_connect())))
 
             while True:
-                data: bytes = await reader.read(1024)
+                if self.separator != None:
+                    data: bytes = await reader.readuntil(separator=self.separator.encode())
+                else:
+                    data: bytes = await reader.read(1024)
+
                 if data == b"":
                     break
                 addr = writer.get_extra_info("peername")

--- a/src/tickit/adapters/io/tcp_io.py
+++ b/src/tickit/adapters/io/tcp_io.py
@@ -80,7 +80,7 @@ class TcpIo(AdapterIo[CommandAdapter]):
             tasks.append(asyncio.create_task(reply(on_connect())))
 
             while True:
-                if self.separator != None:
+                if self.separator is not None:
                     data: bytes = await reader.readuntil(separator=self.separator.encode())
                 else:
                     data: bytes = await reader.read(1024)


### PR DESCRIPTION
When communicating with a simulated device using an ascii protocol I found that the StreamReader.read() method returns inconsistent number of bytes. Even the documentation alludes to this inconsistency:

_If n is positive, this function try to read `n` bytes, and may return
less or equal bytes than requested, but at least one byte. If EOF was
received before any byte is read, this function returns empty byte
object._

As the majority of devices that communicate using an ascii based protocol rely on a termination character to determine the end of a message I have added this as an optional parameter in the tickit.adapters.io.TcpIo class.